### PR TITLE
Enforce Squad subagent preflight

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -76,11 +76,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 **Sub-session rules (App mode only):**
 - Use `create_session` for agents that produce commits (code, config, docs)
 - Use `task` tool for pure analysis, coordination, or read-only research
+- **Default agent:** Set `kickoff.agent: "Squad"` for every new sub-session unless the user or task explicitly requires another installed custom agent. The kickoff prompt still names the accountable crew specialist and inlines their charter.
+- **Inherit parent configuration:** Prefer the current parent session's model, context tier, reasoning effort, and mode when the child surface supports them. Diverge only for availability, an explicit user override, or a documented task requirement; state the fallback in the spawn acknowledgment.
 - **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
 - **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
 - **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
 - **Fallback:** If `create_session` fails for an agent, retry with `task` tool
-- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.agent: "Squad"`, and inherited `kickoff.mode`, `kickoff.model`, `kickoff.context_tier`, and `kickoff.reasoning_effort` when supported.
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
@@ -536,11 +538,23 @@ Each entry records: agent routed, why chosen, mode (background/sync), files auth
 
 Before issue-based spawns, check whether worktree mode is active. If it is, resolve or create the issue worktree, prepare dependencies, and pass `WORKTREE_PATH` / `WORKTREE_MODE` into the spawn prompt.
 
+**Fresh-base preflight (mandatory):**
+1. Require a clean worktree; if dirty, stop and surface the owning changes.
+2. Fetch and prune the target remote before resolving a base.
+3. Independent work starts from the verified live `origin/main`.
+4. Dependent/stacked work starts from the verified live remote parent branch, not stale local state.
+5. Reused issue branches should rebase onto that verified base before new work when safe. On conflict, changed remote tip, or force-with-lease failure, stop and restart preflight; never overwrite concurrent work.
+6. Record the base ref/SHA in the spawn prompt.
+
 **On-demand reference:** Read `.squad/templates/worktree-reference.md` for the full pre-spawn worktree checklist and commands.
 
 ### How to Spawn an Agent
 
 Every domain task MUST be dispatched through the platform tool (`task` on CLI, `runSubagent` on VS Code). Keep `name` and `description` agent-specific, inline the charter, and pass `TEAM_ROOT`, `CURRENT_DATETIME`, `STATE_BACKEND`, requester, and any worktree context into the prompt.
+
+In App mode, use the Squad custom agent by default and inherit the parent configuration. In CLI mode, use the Squad agent when the task tool advertises it; otherwise use `general-purpose` with the same supported model/reasoning/context configuration and inline Squad/charter rules. VS Code accepts its parent/default model where per-spawn selection is unavailable.
+
+**Pre-PR validation gate:** Before any agent opens a PR, it must run the smallest complete existing local build, test, lint, type-check, documentation/link, configuration, and scenario checks required by the issue. Record commands and results in the issue and PR. A failing required check blocks PR creation unless the user explicitly approves a draft blocker for an unavailable external dependency; never present an untested PR as ready.
 
 **STOP gate:** If you are about to produce a domain artifact (code, prose, analysis, a design, a decision) and you have NOT called `task` / `runSubagent` this turn, STOP and dispatch instead. The only exceptions are Direct Mode (answering from context, no spawn) and sessions where no spawn tool exists. "I'll just do this one myself" is the regression this gate prevents.
 
@@ -726,7 +740,7 @@ When `.squad/team.md` exists but `.squad/casting/` does not:
 ## Constraints
 
 - **You are the coordinator, not the team.** Route work; don't do domain work yourself.
-- **Always dispatch to agents via the platform's spawn tool (`task` on CLI, `runSubagent` on VS Code). Never work inline when a dispatch tool is available.** Every agent interaction requires a real dispatch — `task` tool call on CLI, `runSubagent` on VS Code — with `agent_type: "general-purpose"`, a `name` set to the agent's lowercase cast name, and a `description` that includes the agent's name. Never simulate or role-play an agent's response.
+- **Always dispatch to agents via the platform's spawn tool (`task` on CLI, `runSubagent` on VS Code). Never work inline when a dispatch tool is available.** Every agent interaction requires a real dispatch — use `agent_type: "Squad"` when the task tool advertises it, otherwise `agent_type: "general-purpose"` with Squad/charter rules inlined. Set `name` to the agent's lowercase cast name and include the agent's name in `description`. Never simulate or role-play an agent's response.
 - **Each agent may read ONLY: its own files + `.squad/decisions.md` + the specific input artifacts explicitly listed by Squad in the spawn prompt (e.g., the file(s) under review).** Never load all charters at once.
 - **Keep responses human.** Say "{AgentName} is looking at this" not "Spawning backend-dev agent."
 - **1-2 agents per question, not all of them.** Not everyone needs to speak.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,11 @@ You are working on a project that uses **Squad**, an AI team framework. When pic
   assigned crew charter before changing code.
 - `main` is the integration branch. Use one issue, `squad/{issue}-{slug}`
   branch, isolated worktree, and draft PR.
+- At issue start, require a clean worktree, fetch/prune, and rebase from the
+  verified live `origin/main` or stacked parent branch. Stop on conflict or a
+  changed remote tip; never overwrite concurrent work.
+- New App sub-sessions default to the `Squad` agent and inherit the parent
+  model/context/reasoning/mode when supported.
 - Use dependent/stacked PRs only when work truly depends on an unmerged layer.
 - Never post personal data, prompts, connector content, tokens, or private
   diagnostics in issues, PRs, logs, telemetry, or committed Squad state.
@@ -66,6 +71,9 @@ When opening a PR:
 - If this is a 🟡 needs-review task, add to the PR description: `⚠️ This task was flagged as "needs review" — please have a squad member review before merging.`
 - Follow any project conventions in `.squad/decisions.md`
 - Target `main` unless the issue explicitly identifies a lower stacked PR.
+- Run the smallest complete existing local validation for the issue first and
+  record exact commands/results. Required failures block readiness and normally
+  block PR creation.
 
 ## Decisions
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,8 @@ docs/charter.md. Write "Not applicable" only with a reason.
 
 ## Validation
 
-<!-- List automated, live, failure-path, accessibility, and help evidence. -->
+<!-- List exact local commands/results run before this PR, plus automated, live,
+failure-path, accessibility, and help evidence. -->
 
 ## Gates
 
@@ -26,6 +27,7 @@ docs/charter.md. Write "Not applicable" only with a reason.
 - [ ] Security/privacy/legal review recorded or not applicable
 - [ ] Cost/operability impact recorded or not applicable
 - [ ] Company charter impact recorded or not applicable
+- [ ] Applicable local build/test/lint/type/docs/config/scenario checks passed
 - [ ] User help/release notes updated or not applicable
 - [ ] No personal data, prompts, credentials, or connector content included
 

--- a/.github/skills/agent-collaboration/SKILL.md
+++ b/.github/skills/agent-collaboration/SKILL.md
@@ -17,6 +17,17 @@ The coordinator's spawn prompt already instructs agents to read decisions.md and
 ### Worktree Awareness
 Use the `TEAM ROOT` path provided in your spawn prompt. All `.squad/` paths are relative to this root. If TEAM ROOT is not provided (rare), run `git rev-parse --show-toplevel` as fallback. Never assume CWD is the repo root.
 
+### Start-of-Work Sync
+Before editing, require a clean worktree, fetch/prune the remote, and rebase the
+issue branch onto the verified live `origin/main` or stacked parent branch.
+Stop on dirty state, conflict, changed remote tip, or lease failure; never
+overwrite another worktree.
+
+### Pre-PR Validation
+Before opening or marking a PR ready, run the smallest complete existing local
+build/test/lint/type/docs/config/scenario checks required by the issue. Record
+commands and results in the issue and PR. Required failures block readiness.
+
 ### Decision Recording
 After making a decision that affects other team members, write it to:
 `.squad/decisions/inbox/{your-name}-{brief-slug}.md`
@@ -40,3 +51,5 @@ If you have reviewer authority and reject work: the original author is locked ou
 - Don't write directly to `.squad/decisions.md` — always use the inbox drop-box
 - Don't modify other agents' history.md files — that's Scribe's job
 - Don't assume CWD is the repo root — always use TEAM ROOT
+- Don't start from stale local `main` or an unverified stacked parent
+- Don't post a PR before running applicable local validation

--- a/.github/skills/git-workflow/SKILL.md
+++ b/.github/skills/git-workflow/SKILL.md
@@ -1,204 +1,107 @@
 ---
 name: "git-workflow"
-description: "Squad branching model: dev-first workflow with insiders preview channel"
+description: "Andreja protected-main, worktree, stacked-PR, and validation workflow"
 domain: "version-control"
 confidence: "high"
 source: "team-decision"
 ---
 
-## Context
+# Andreja Git Workflow
 
-Squad uses a three-branch model. **All feature work starts from `dev`, not `main`.**
+## Integration model
 
-| Branch | Purpose | Publishes |
-|--------|---------|-----------|
-| `main` | Released, tagged, in-npm code only | `npm publish` on tag |
-| `dev` | Integration branch — all feature work lands here | `npm publish --tag preview` on merge |
-| `insiders` | Early-access channel — synced from dev | `npm publish --tag insiders` on sync |
+- `main` is the integration and release branch.
+- Never commit or push directly to `main`.
+- One GitHub issue owns one `squad/{issue-number}-{slug}` branch, isolated
+  worktree, accountable agent, and PR.
+- Independent ready issues run in parallel worktrees.
+- Dependent slices use ordinary dependent PRs and GitHub native stack metadata
+  when the preview/API/entitlement supports it.
 
-## Branch Naming Convention
+## Start-of-work preflight
 
-Issue branches MUST use: `squad/{issue-number}-{kebab-case-slug}`
+Before creating or reusing an issue worktree:
 
-Examples:
-- `squad/195-fix-version-stamp-bug`
-- `squad/42-add-profile-api`
+1. Require a clean current/target worktree. Stop rather than move or overwrite
+   somebody else's changes.
+2. Validate the configured remote and run `git fetch --prune origin`.
+3. Resolve and record the live base ref/SHA:
+   - Independent work: `origin/main`.
+   - Stacked work: the verified remote parent branch named by the issue.
+4. Create a new worktree from that remote ref, or rebase a clean existing issue
+   branch onto it.
+5. On conflict, changed remote tip, missing parent, or force-with-lease failure,
+   stop and restart preflight. Never force over concurrent work.
 
-## Workflow for Issue Work
+Example:
 
-1. **Branch from dev:**
-   ```bash
-   git checkout dev
-   git pull origin dev
-   git checkout -b squad/{issue-number}-{slug}
-   ```
-
-2. **Mark issue in-progress:**
-   ```bash
-   gh issue edit {number} --add-label "status:in-progress"
-   ```
-
-3. **Create draft PR targeting dev:**
-   ```bash
-   gh pr create --base dev --title "{description}" --body "Closes #{issue-number}" --draft
-   ```
-
-4. **Do the work.** Make changes, write tests, commit with issue reference.
-
-5. **Push and mark ready:**
-   ```bash
-   git push -u origin squad/{issue-number}-{slug}
-   gh pr ready
-   ```
-
-6. **After merge to dev:**
-   ```bash
-   git checkout dev
-   git pull origin dev
-   git branch -d squad/{issue-number}-{slug}
-   git push origin --delete squad/{issue-number}-{slug}
-   ```
-
-## Parallel Multi-Issue Work (Worktrees)
-
-When the coordinator routes multiple issues simultaneously (e.g., "fix bugs X, Y, and Z"), use `git worktree` to give each agent an isolated working directory. No filesystem collisions, no branch-switching overhead.
-
-### When to Use Worktrees vs Sequential
-
-| Scenario | Strategy |
-|----------|----------|
-| Single issue | Standard workflow above — no worktree needed |
-| 2+ simultaneous issues in same repo | Worktrees — one per issue |
-| Work spanning multiple repos | Separate clones as siblings (see Multi-Repo below) |
-
-### Setup
-
-From the main clone (must be on dev or any branch):
-
-```bash
-# Ensure dev is current
-git fetch origin dev
-
-# Create a worktree per issue — siblings to the main clone
-git worktree add ../squad-195 -b squad/195-fix-stamp-bug origin/dev
-git worktree add ../squad-193 -b squad/193-refactor-loader origin/dev
+```powershell
+git fetch --prune origin
+git worktree add ..\Andreja-42 -b squad/42-fix-login origin/main
 ```
 
-**Naming convention:** `../{repo-name}-{issue-number}` (e.g., `../squad-195`, `../squad-pr-42`).
+## Sub-session configuration
 
-Each worktree:
-- Has its own working directory and index
-- Is on its own `squad/{issue-number}-{slug}` branch from dev
-- Shares the same `.git` object store (disk-efficient)
+- In Copilot App, default new sub-sessions to the `Squad` custom agent.
+- Preserve the parent model, context tier, reasoning effort, and mode when the
+  child surface/model supports them.
+- Diverge only for availability, explicit user direction, or a documented task
+  need; report the fallback.
+- The kickoff prompt still names the accountable crew specialist and includes
+  their charter, issue, base ref/SHA, worktree path, and validation commands.
 
-### Per-Worktree Agent Workflow
+## Issue workflow
 
-Each agent operates inside its worktree exactly like the single-issue workflow:
+1. Add `status:in-progress` and the accountable `squad:{member}` label.
+2. Create or reuse the isolated issue worktree after preflight.
+3. Open a draft PR only after an initial coherent commit and required local
+   validation.
+4. Keep issue and PR updated with dependencies, evidence, risks, and blockers.
+5. Merge through native protections/queue when available, or the documented
+   reviewed-PR procedural fallback.
+6. After merge, remove the worktree, prune metadata, delete the issue branch,
+   and update the issue/milestone.
 
-```bash
-cd ../squad-195
+## Local validation before PR
 
-# Work normally — commits, tests, pushes
-git add -A && git commit -m "fix: stamp bug (#195)"
-git push -u origin squad/195-fix-stamp-bug
+Before creating or marking a PR ready:
 
-# Create PR targeting dev
-gh pr create --base dev --title "fix: stamp bug" --body "Closes #195" --draft
-```
+- Run the smallest complete existing checks required by the issue: build, unit
+  and integration tests, lint/format/type-check, docs/link/config validation,
+  targeted E2E/scenario checks, and security/privacy evidence as applicable.
+- Record exact commands and results in the issue and PR.
+- A failing required check blocks PR creation/readiness unless Cyrus explicitly
+  approves a draft blocker for an unavailable external dependency.
+- Never describe untested work as ready to merge.
 
-All PRs target `dev` independently. Agents never interfere with each other's filesystem.
+## Stacked PR rules
 
-### .squad/ State in Worktrees
+- Bottom PR targets `main`; each higher PR targets the branch immediately below.
+- Create layers sequentially bottom-to-top after the lower branch is pushed.
+- Register stack metadata only after every PR is open, same-repository, not
+  queued/auto-merging, and has the exact verified base/head chain.
+- Preserve stack identity after partial merges; append only above the verified
+  top.
+- Rebase/sync inside each layer's owning worktree. Use explicit
+  `--force-with-lease` only after recording and revalidating the remote tip.
+- If native stacks are unavailable, keep the ordinary dependent-PR chain.
 
-The `.squad/` directory exists in each worktree as a copy. This is safe because:
-- `.gitattributes` declares `merge=union` on append-only files (history.md, decisions.md, logs)
-- Each agent appends to its own section; union merge reconciles on PR merge to dev
-- **Rule:** Never rewrite or reorder `.squad/` files in a worktree — append only
+## Multi-repository work
 
-### Cleanup After Merge
+- Use separate sibling clones for separate repositories, not worktrees across
+  repositories.
+- Give each repository its own issue branch and PR.
+- Link dependencies and merge dependency repositories first.
+- Remove local package links/replacements before commit; CI must verify using
+  published or PR-specific references.
 
-After a worktree's PR is merged to dev:
+## Anti-patterns
 
-```bash
-# From the main clone
-git worktree remove ../squad-195
-git worktree prune          # clean stale metadata
-git branch -d squad/195-fix-stamp-bug
-git push origin --delete squad/195-fix-stamp-bug
-```
-
-If a worktree was deleted manually (rm -rf), `git worktree prune` recovers the state.
-
----
-
-## Multi-Repo Downstream Scenarios
-
-When work spans multiple repositories (e.g., squad-cli changes need squad-sdk changes, or a user's app depends on squad):
-
-### Setup
-
-Clone downstream repos as siblings to the main repo:
-
-```
-~/work/
-  squad-pr/          # main repo
-  squad-sdk/         # downstream dependency
-  user-app/          # consumer project
-```
-
-Each repo gets its own issue branch following its own naming convention. If the downstream repo also uses Squad conventions, use `squad/{issue-number}-{slug}`.
-
-### Coordinated PRs
-
-- Create PRs in each repo independently
-- Link them in PR descriptions:
-  ```
-  Closes #42
-
-  **Depends on:** squad-sdk PR #17 (squad-sdk changes required for this feature)
-  ```
-- Merge order: dependencies first (e.g., squad-sdk), then dependents (e.g., squad-cli)
-
-### Local Linking for Testing
-
-Before pushing, verify cross-repo changes work together:
-
-```bash
-# Node.js / npm
-cd ../squad-sdk && npm link
-cd ../squad-pr && npm link squad-sdk
-
-# Go
-# Use replace directive in go.mod:
-# replace github.com/org/squad-sdk => ../squad-sdk
-
-# Python
-cd ../squad-sdk && pip install -e .
-```
-
-**Important:** Remove local links before committing. `npm link` and `go replace` are dev-only — CI must use published packages or PR-specific refs.
-
-### Worktrees + Multi-Repo
-
-These compose naturally. You can have:
-- Multiple worktrees in the main repo (parallel issues)
-- Separate clones for downstream repos
-- Each combination operates independently
-
----
-
-## Anti-Patterns
-
-- ❌ Branching from main (branch from dev)
-- ❌ PR targeting main directly (target dev)
-- ❌ Non-conforming branch names (must be squad/{number}-{slug})
-- ❌ Committing directly to main or dev (use PRs)
-- ❌ Switching branches in the main clone while worktrees are active (use worktrees instead)
-- ❌ Using worktrees for cross-repo work (use separate clones)
-- ❌ Leaving stale worktrees after PR merge (clean up immediately)
-
-## Promotion Pipeline
-
-- dev → insiders: Automated sync on green build
-- dev → main: Manual merge when ready for stable release, then tag
-- Hotfixes: Branch from main as `hotfix/{slug}`, PR to dev, cherry-pick to main if urgent
+- Starting from stale local `main` or an unverified parent branch.
+- Working in a dirty or somebody else's worktree.
+- Multiple independent issues sharing one branch/PR.
+- Opening a PR before running applicable local validation.
+- Force-pushing without an explicit lease.
+- Rebasing or pushing another active worktree's branch.
+- Hiding test failures, dependency drift, or stacked-PR order.
+- Leaving merged worktrees/branches behind.

--- a/.squad/directives.md
+++ b/.squad/directives.md
@@ -26,8 +26,16 @@
 
 - `main` is the integration/release branch.
 - One issue, `squad/{issue}-{slug}` branch, worktree, owner and draft PR.
+- Before creating/reusing a worktree, fetch/prune and rebase from live
+  `origin/main` or the verified remote stacked parent; stop on dirty state,
+  conflicts, changed remote tips, or lease failure.
+- New App sub-sessions use the `Squad` agent by default and inherit the parent
+  model, context tier, reasoning effort, and mode where supported; any fallback
+  is explicit.
 - Parallelize independent ready issues; agree shared contracts first.
 - Use native stacked PRs for dependent slices when available.
+- Before opening or marking a PR ready, run the issue's applicable local build,
+  tests, lint/type/config/docs/E2E checks and record commands/results.
 - Require issue-linked acceptance, tests, help and artifact gates.
 - Apply reviewer lockout after rejection.
 

--- a/.squad/templates/skills/agent-collaboration/SKILL.md
+++ b/.squad/templates/skills/agent-collaboration/SKILL.md
@@ -17,6 +17,17 @@ The coordinator's spawn prompt already instructs agents to read decisions.md and
 ### Worktree Awareness
 Use the `TEAM ROOT` path provided in your spawn prompt. All `.squad/` paths are relative to this root. If TEAM ROOT is not provided (rare), run `git rev-parse --show-toplevel` as fallback. Never assume CWD is the repo root.
 
+### Start-of-Work Sync
+Before editing, require a clean worktree, fetch/prune the remote, and rebase the
+issue branch onto the verified live `origin/main` or stacked parent branch.
+Stop on dirty state, conflict, changed remote tip, or lease failure; never
+overwrite another worktree.
+
+### Pre-PR Validation
+Before opening or marking a PR ready, run the smallest complete existing local
+build/test/lint/type/docs/config/scenario checks required by the issue. Record
+commands and results in the issue and PR. Required failures block readiness.
+
 ### Decision Recording
 After making a decision that affects other team members, write it to:
 `.squad/decisions/inbox/{your-name}-{brief-slug}.md`
@@ -40,3 +51,5 @@ If you have reviewer authority and reject work: the original author is locked ou
 - Don't write directly to `.squad/decisions.md` — always use the inbox drop-box
 - Don't modify other agents' history.md files — that's Scribe's job
 - Don't assume CWD is the repo root — always use TEAM ROOT
+- Don't start from stale local `main` or an unverified stacked parent
+- Don't post a PR before running applicable local validation

--- a/.squad/templates/skills/git-workflow/SKILL.md
+++ b/.squad/templates/skills/git-workflow/SKILL.md
@@ -1,204 +1,107 @@
 ---
 name: "git-workflow"
-description: "Squad branching model: dev-first workflow with insiders preview channel"
+description: "Andreja protected-main, worktree, stacked-PR, and validation workflow"
 domain: "version-control"
 confidence: "high"
 source: "team-decision"
 ---
 
-## Context
+# Andreja Git Workflow
 
-Squad uses a three-branch model. **All feature work starts from `dev`, not `main`.**
+## Integration model
 
-| Branch | Purpose | Publishes |
-|--------|---------|-----------|
-| `main` | Released, tagged, in-npm code only | `npm publish` on tag |
-| `dev` | Integration branch — all feature work lands here | `npm publish --tag preview` on merge |
-| `insiders` | Early-access channel — synced from dev | `npm publish --tag insiders` on sync |
+- `main` is the integration and release branch.
+- Never commit or push directly to `main`.
+- One GitHub issue owns one `squad/{issue-number}-{slug}` branch, isolated
+  worktree, accountable agent, and PR.
+- Independent ready issues run in parallel worktrees.
+- Dependent slices use ordinary dependent PRs and GitHub native stack metadata
+  when the preview/API/entitlement supports it.
 
-## Branch Naming Convention
+## Start-of-work preflight
 
-Issue branches MUST use: `squad/{issue-number}-{kebab-case-slug}`
+Before creating or reusing an issue worktree:
 
-Examples:
-- `squad/195-fix-version-stamp-bug`
-- `squad/42-add-profile-api`
+1. Require a clean current/target worktree. Stop rather than move or overwrite
+   somebody else's changes.
+2. Validate the configured remote and run `git fetch --prune origin`.
+3. Resolve and record the live base ref/SHA:
+   - Independent work: `origin/main`.
+   - Stacked work: the verified remote parent branch named by the issue.
+4. Create a new worktree from that remote ref, or rebase a clean existing issue
+   branch onto it.
+5. On conflict, changed remote tip, missing parent, or force-with-lease failure,
+   stop and restart preflight. Never force over concurrent work.
 
-## Workflow for Issue Work
+Example:
 
-1. **Branch from dev:**
-   ```bash
-   git checkout dev
-   git pull origin dev
-   git checkout -b squad/{issue-number}-{slug}
-   ```
-
-2. **Mark issue in-progress:**
-   ```bash
-   gh issue edit {number} --add-label "status:in-progress"
-   ```
-
-3. **Create draft PR targeting dev:**
-   ```bash
-   gh pr create --base dev --title "{description}" --body "Closes #{issue-number}" --draft
-   ```
-
-4. **Do the work.** Make changes, write tests, commit with issue reference.
-
-5. **Push and mark ready:**
-   ```bash
-   git push -u origin squad/{issue-number}-{slug}
-   gh pr ready
-   ```
-
-6. **After merge to dev:**
-   ```bash
-   git checkout dev
-   git pull origin dev
-   git branch -d squad/{issue-number}-{slug}
-   git push origin --delete squad/{issue-number}-{slug}
-   ```
-
-## Parallel Multi-Issue Work (Worktrees)
-
-When the coordinator routes multiple issues simultaneously (e.g., "fix bugs X, Y, and Z"), use `git worktree` to give each agent an isolated working directory. No filesystem collisions, no branch-switching overhead.
-
-### When to Use Worktrees vs Sequential
-
-| Scenario | Strategy |
-|----------|----------|
-| Single issue | Standard workflow above — no worktree needed |
-| 2+ simultaneous issues in same repo | Worktrees — one per issue |
-| Work spanning multiple repos | Separate clones as siblings (see Multi-Repo below) |
-
-### Setup
-
-From the main clone (must be on dev or any branch):
-
-```bash
-# Ensure dev is current
-git fetch origin dev
-
-# Create a worktree per issue — siblings to the main clone
-git worktree add ../squad-195 -b squad/195-fix-stamp-bug origin/dev
-git worktree add ../squad-193 -b squad/193-refactor-loader origin/dev
+```powershell
+git fetch --prune origin
+git worktree add ..\Andreja-42 -b squad/42-fix-login origin/main
 ```
 
-**Naming convention:** `../{repo-name}-{issue-number}` (e.g., `../squad-195`, `../squad-pr-42`).
+## Sub-session configuration
 
-Each worktree:
-- Has its own working directory and index
-- Is on its own `squad/{issue-number}-{slug}` branch from dev
-- Shares the same `.git` object store (disk-efficient)
+- In Copilot App, default new sub-sessions to the `Squad` custom agent.
+- Preserve the parent model, context tier, reasoning effort, and mode when the
+  child surface/model supports them.
+- Diverge only for availability, explicit user direction, or a documented task
+  need; report the fallback.
+- The kickoff prompt still names the accountable crew specialist and includes
+  their charter, issue, base ref/SHA, worktree path, and validation commands.
 
-### Per-Worktree Agent Workflow
+## Issue workflow
 
-Each agent operates inside its worktree exactly like the single-issue workflow:
+1. Add `status:in-progress` and the accountable `squad:{member}` label.
+2. Create or reuse the isolated issue worktree after preflight.
+3. Open a draft PR only after an initial coherent commit and required local
+   validation.
+4. Keep issue and PR updated with dependencies, evidence, risks, and blockers.
+5. Merge through native protections/queue when available, or the documented
+   reviewed-PR procedural fallback.
+6. After merge, remove the worktree, prune metadata, delete the issue branch,
+   and update the issue/milestone.
 
-```bash
-cd ../squad-195
+## Local validation before PR
 
-# Work normally — commits, tests, pushes
-git add -A && git commit -m "fix: stamp bug (#195)"
-git push -u origin squad/195-fix-stamp-bug
+Before creating or marking a PR ready:
 
-# Create PR targeting dev
-gh pr create --base dev --title "fix: stamp bug" --body "Closes #195" --draft
-```
+- Run the smallest complete existing checks required by the issue: build, unit
+  and integration tests, lint/format/type-check, docs/link/config validation,
+  targeted E2E/scenario checks, and security/privacy evidence as applicable.
+- Record exact commands and results in the issue and PR.
+- A failing required check blocks PR creation/readiness unless Cyrus explicitly
+  approves a draft blocker for an unavailable external dependency.
+- Never describe untested work as ready to merge.
 
-All PRs target `dev` independently. Agents never interfere with each other's filesystem.
+## Stacked PR rules
 
-### .squad/ State in Worktrees
+- Bottom PR targets `main`; each higher PR targets the branch immediately below.
+- Create layers sequentially bottom-to-top after the lower branch is pushed.
+- Register stack metadata only after every PR is open, same-repository, not
+  queued/auto-merging, and has the exact verified base/head chain.
+- Preserve stack identity after partial merges; append only above the verified
+  top.
+- Rebase/sync inside each layer's owning worktree. Use explicit
+  `--force-with-lease` only after recording and revalidating the remote tip.
+- If native stacks are unavailable, keep the ordinary dependent-PR chain.
 
-The `.squad/` directory exists in each worktree as a copy. This is safe because:
-- `.gitattributes` declares `merge=union` on append-only files (history.md, decisions.md, logs)
-- Each agent appends to its own section; union merge reconciles on PR merge to dev
-- **Rule:** Never rewrite or reorder `.squad/` files in a worktree — append only
+## Multi-repository work
 
-### Cleanup After Merge
+- Use separate sibling clones for separate repositories, not worktrees across
+  repositories.
+- Give each repository its own issue branch and PR.
+- Link dependencies and merge dependency repositories first.
+- Remove local package links/replacements before commit; CI must verify using
+  published or PR-specific references.
 
-After a worktree's PR is merged to dev:
+## Anti-patterns
 
-```bash
-# From the main clone
-git worktree remove ../squad-195
-git worktree prune          # clean stale metadata
-git branch -d squad/195-fix-stamp-bug
-git push origin --delete squad/195-fix-stamp-bug
-```
-
-If a worktree was deleted manually (rm -rf), `git worktree prune` recovers the state.
-
----
-
-## Multi-Repo Downstream Scenarios
-
-When work spans multiple repositories (e.g., squad-cli changes need squad-sdk changes, or a user's app depends on squad):
-
-### Setup
-
-Clone downstream repos as siblings to the main repo:
-
-```
-~/work/
-  squad-pr/          # main repo
-  squad-sdk/         # downstream dependency
-  user-app/          # consumer project
-```
-
-Each repo gets its own issue branch following its own naming convention. If the downstream repo also uses Squad conventions, use `squad/{issue-number}-{slug}`.
-
-### Coordinated PRs
-
-- Create PRs in each repo independently
-- Link them in PR descriptions:
-  ```
-  Closes #42
-
-  **Depends on:** squad-sdk PR #17 (squad-sdk changes required for this feature)
-  ```
-- Merge order: dependencies first (e.g., squad-sdk), then dependents (e.g., squad-cli)
-
-### Local Linking for Testing
-
-Before pushing, verify cross-repo changes work together:
-
-```bash
-# Node.js / npm
-cd ../squad-sdk && npm link
-cd ../squad-pr && npm link squad-sdk
-
-# Go
-# Use replace directive in go.mod:
-# replace github.com/org/squad-sdk => ../squad-sdk
-
-# Python
-cd ../squad-sdk && pip install -e .
-```
-
-**Important:** Remove local links before committing. `npm link` and `go replace` are dev-only — CI must use published packages or PR-specific refs.
-
-### Worktrees + Multi-Repo
-
-These compose naturally. You can have:
-- Multiple worktrees in the main repo (parallel issues)
-- Separate clones for downstream repos
-- Each combination operates independently
-
----
-
-## Anti-Patterns
-
-- ❌ Branching from main (branch from dev)
-- ❌ PR targeting main directly (target dev)
-- ❌ Non-conforming branch names (must be squad/{number}-{slug})
-- ❌ Committing directly to main or dev (use PRs)
-- ❌ Switching branches in the main clone while worktrees are active (use worktrees instead)
-- ❌ Using worktrees for cross-repo work (use separate clones)
-- ❌ Leaving stale worktrees after PR merge (clean up immediately)
-
-## Promotion Pipeline
-
-- dev → insiders: Automated sync on green build
-- dev → main: Manual merge when ready for stable release, then tag
-- Hotfixes: Branch from main as `hotfix/{slug}`, PR to dev, cherry-pick to main if urgent
+- Starting from stale local `main` or an unverified parent branch.
+- Working in a dirty or somebody else's worktree.
+- Multiple independent issues sharing one branch/PR.
+- Opening a PR before running applicable local validation.
+- Force-pushing without an explicit lease.
+- Rebasing or pushing another active worktree's branch.
+- Hiding test failures, dependency drift, or stacked-PR order.
+- Leaving merged worktrees/branches behind.

--- a/.squad/templates/spawn-reference.md
+++ b/.squad/templates/spawn-reference.md
@@ -27,9 +27,12 @@ When `create_session` is available, spawn commit-producing agents as **sub-sessi
 - **`name`**: `"{Name} {verb}ing {noun}"` — 40-char max, sentence case (e.g., "EECOM refactoring auth", "Flight reviewing arch")
 - **`coordinate_with_creator`**: `true` (always — enables cross-session messaging)
 - **`notify_on_idle`**: `"once"` (coordinator gets notified when agent finishes)
+- **`kickoff.agent`**: `"Squad"` by default; use another installed custom agent only when explicitly required
 - **`kickoff.prompt`**: The full agent prompt (same as task prompt below)
-- **`kickoff.mode`**: `"autopilot"` (agents work autonomously)
-- **`kickoff.model`**: `"{resolved_model}"`
+- **`kickoff.mode`**: `"{parent_mode}"` when supported; otherwise the documented task fallback
+- **`kickoff.model`**: `"{parent_model}"` when supported; otherwise `"{resolved_model}"`
+- **`kickoff.context_tier`**: `"{parent_context_tier}"` when supported
+- **`kickoff.reasoning_effort`**: `"{parent_reasoning_effort}"` when supported; otherwise `"{resolved_effort}"`
 
 **Constraints:**
 - **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
@@ -43,13 +46,19 @@ create_session({
   coordinate_with_creator: true,
   notify_on_idle: "once",
   kickoff: {
+    agent: "Squad",
     prompt: "{full agent prompt — see template below}",
-    mode: "autopilot",
-    model: "{resolved_model}",
-    reasoning_effort: "{resolved_effort}"
+    mode: "{parent_mode}",
+    model: "{parent_model_or_resolved_model}",
+    context_tier: "{parent_context_tier}",
+    reasoning_effort: "{parent_reasoning_effort_or_resolved_effort}"
   }
 })
 ```
+
+If a parent setting is unavailable or unsupported by the selected model/client,
+omit that field and record the fallback. Never silently switch model or
+reasoning configuration.
 
 **Result collection:** When `notify_on_idle` fires, the coordinator receives the session result via cross-session notification. No polling required.
 
@@ -59,7 +68,7 @@ create_session({
 
 Standard spawn via `task` tool — used in CLI, or as fallback when `create_session` is unavailable:
 
-- **`agent_type`**: `"general-purpose"` (always — this gives agents full tool access)
+- **`agent_type`**: `"Squad"` when the task tool advertises the custom agent; otherwise `"general-purpose"` with Squad and specialist charter instructions inlined
 - **`mode`**: `"background"` (default) or `"sync"` — use `"background"` for all parallelizable work; use `"sync"` only when the result is needed before the next step can proceed
 - **`description`**: `"{Name}: {brief task summary}"` (e.g., `"Ripley: Design REST API endpoints"`, `"Dallas: Build login form"`) — this is what appears in the UI, so it MUST carry the agent's name and what they're doing
 - **`prompt`**: The full agent prompt (see below)
@@ -75,8 +84,10 @@ Standard spawn via `task` tool — used in CLI, or as fallback when `create_sess
 **Template for any agent** (substitute `{Name}`, `{Role}`, `{name}`, and inline the charter):
 
 ```
-agent_type: "general-purpose"
-model: "{resolved_model}"
+agent_type: "{Squad_if_advertised_else_general-purpose}"
+model: "{parent_model_or_resolved_model}"
+reasoning_effort: "{parent_reasoning_effort_or_resolved_effort}"
+context_tier: "{parent_context_tier}"
 mode: "background"
 name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
@@ -107,11 +118,16 @@ prompt: |
 
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
+  BASE_REF: {verified_remote_base_ref}
+  BASE_SHA: {verified_remote_base_sha}
 
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
   - Do NOT switch branches — the worktree IS your branch (`{branch_name}`)
+  - Start clean: fetch/prune the remote and rebase onto `BASE_REF` when safe
+  - For independent work `BASE_REF` is live `origin/main`; for stacked work it is the verified remote parent branch
+  - Stop on dirty state, changed remote tip, conflict, or lease failure; never overwrite concurrent work
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
@@ -138,6 +154,13 @@ prompt: |
   If .squad/identity/now.md exists, read it at spawn time.
   Check project skill directories (.squad/skills/, .github/skills/, .copilot/skills/, .claude/skills/, .agents/skills/) for any SKILL.md the coordinator attached to your prompt.
   Read any relevant SKILL.md files before working.
+
+  Before opening a PR:
+  - Run the smallest complete existing local validation required by the issue
+    (build/test/lint/type-check/docs/config/scenario checks as applicable)
+  - Record the exact commands and results in the issue and PR
+  - Do not open or mark ready a PR with failing required checks unless the user
+    explicitly approved a draft blocker for an unavailable external dependency
 
   ⚠️ WORK FRESHNESS: When determining what to work on:
   - If an external tracker is configured (GitHub Issues, GitLab Issues, Azure DevOps),

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -76,11 +76,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 **Sub-session rules (App mode only):**
 - Use `create_session` for agents that produce commits (code, config, docs)
 - Use `task` tool for pure analysis, coordination, or read-only research
+- **Default agent:** Set `kickoff.agent: "Squad"` for every new sub-session unless the user or task explicitly requires another installed custom agent. The kickoff prompt still names the accountable crew specialist and inlines their charter.
+- **Inherit parent configuration:** Prefer the current parent session's model, context tier, reasoning effort, and mode when the child surface supports them. Diverge only for availability, an explicit user override, or a documented task requirement; state the fallback in the spawn acknowledgment.
 - **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
 - **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
 - **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
 - **Fallback:** If `create_session` fails for an agent, retry with `task` tool
-- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.agent: "Squad"`, and inherited `kickoff.mode`, `kickoff.model`, `kickoff.context_tier`, and `kickoff.reasoning_effort` when supported.
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
@@ -536,11 +538,23 @@ Each entry records: agent routed, why chosen, mode (background/sync), files auth
 
 Before issue-based spawns, check whether worktree mode is active. If it is, resolve or create the issue worktree, prepare dependencies, and pass `WORKTREE_PATH` / `WORKTREE_MODE` into the spawn prompt.
 
+**Fresh-base preflight (mandatory):**
+1. Require a clean worktree; if dirty, stop and surface the owning changes.
+2. Fetch and prune the target remote before resolving a base.
+3. Independent work starts from the verified live `origin/main`.
+4. Dependent/stacked work starts from the verified live remote parent branch, not stale local state.
+5. Reused issue branches should rebase onto that verified base before new work when safe. On conflict, changed remote tip, or force-with-lease failure, stop and restart preflight; never overwrite concurrent work.
+6. Record the base ref/SHA in the spawn prompt.
+
 **On-demand reference:** Read `.squad/templates/worktree-reference.md` for the full pre-spawn worktree checklist and commands.
 
 ### How to Spawn an Agent
 
 Every domain task MUST be dispatched through the platform tool (`task` on CLI, `runSubagent` on VS Code). Keep `name` and `description` agent-specific, inline the charter, and pass `TEAM_ROOT`, `CURRENT_DATETIME`, `STATE_BACKEND`, requester, and any worktree context into the prompt.
+
+In App mode, use the Squad custom agent by default and inherit the parent configuration. In CLI mode, use the Squad agent when the task tool advertises it; otherwise use `general-purpose` with the same supported model/reasoning/context configuration and inline Squad/charter rules. VS Code accepts its parent/default model where per-spawn selection is unavailable.
+
+**Pre-PR validation gate:** Before any agent opens a PR, it must run the smallest complete existing local build, test, lint, type-check, documentation/link, configuration, and scenario checks required by the issue. Record commands and results in the issue and PR. A failing required check blocks PR creation unless the user explicitly approves a draft blocker for an unavailable external dependency; never present an untested PR as ready.
 
 **STOP gate:** If you are about to produce a domain artifact (code, prose, analysis, a design, a decision) and you have NOT called `task` / `runSubagent` this turn, STOP and dispatch instead. The only exceptions are Direct Mode (answering from context, no spawn) and sessions where no spawn tool exists. "I'll just do this one myself" is the regression this gate prevents.
 
@@ -726,7 +740,7 @@ When `.squad/team.md` exists but `.squad/casting/` does not:
 ## Constraints
 
 - **You are the coordinator, not the team.** Route work; don't do domain work yourself.
-- **Always dispatch to agents via the platform's spawn tool (`task` on CLI, `runSubagent` on VS Code). Never work inline when a dispatch tool is available.** Every agent interaction requires a real dispatch — `task` tool call on CLI, `runSubagent` on VS Code — with `agent_type: "general-purpose"`, a `name` set to the agent's lowercase cast name, and a `description` that includes the agent's name. Never simulate or role-play an agent's response.
+- **Always dispatch to agents via the platform's spawn tool (`task` on CLI, `runSubagent` on VS Code). Never work inline when a dispatch tool is available.** Every agent interaction requires a real dispatch — use `agent_type: "Squad"` when the task tool advertises it, otherwise `agent_type: "general-purpose"` with Squad/charter rules inlined. Set `name` to the agent's lowercase cast name and include the agent's name in `description`. Never simulate or role-play an agent's response.
 - **Each agent may read ONLY: its own files + `.squad/decisions.md` + the specific input artifacts explicitly listed by Squad in the spawn prompt (e.g., the file(s) under review).** Never load all charters at once.
 - **Keep responses human.** Say "{AgentName} is looking at this" not "Spawning backend-dev agent."
 - **1-2 agents per question, not all of them.** Not everyone needs to speak.

--- a/.squad/templates/worktree-reference.md
+++ b/.squad/templates/worktree-reference.md
@@ -53,6 +53,9 @@ When worktree mode is enabled, the coordinator creates dedicated worktrees for i
 - Explicit: `worktrees: true` in project config (squad.config.ts or package.json `squad` section)
 - Environment: `SQUAD_WORKTREES=1` set in environment variables
 - Default: `false` (backward compatibility — agents work in the main repo)
+- **Andreja project override:** enabled by default for issue work via
+  `.squad/directives.md`; use an isolated worktree unless the user explicitly
+  requests otherwise.
 
 **Creating worktrees:**
 - One worktree per issue number
@@ -60,6 +63,9 @@ When worktree mode is enabled, the coordinator creates dedicated worktrees for i
 - Path convention: `{repo-parent}/{repo-name}-{issue-number}`
   - Example: Working on issue #42 in `C:\src\squad` → worktree at `C:\src\squad-42`
 - Branch: `squad/{issue-number}-{kebab-case-slug}` (created from base branch, typically `main`)
+- Base: fetch/prune first, then use the verified live remote ref:
+  `origin/main` for independent work or the remote parent branch for a stacked
+  dependency.
 
 **Dependency management:**
 - After creating a worktree, link `node_modules` from the main repo to avoid reinstalling
@@ -98,15 +104,19 @@ b. **Check if worktree already exists:**
    - Run `git worktree list` to see all active worktrees
    - If the worktree path already exists → **reuse it**:
      - Verify the branch is correct (should be `squad/{issue-number}-*`)
-     - `cd` to the worktree path
-     - `git pull` to sync latest changes
+     - Require `git status --porcelain` to be empty
+     - Fetch/prune the remote and record the base ref/SHA
+     - Rebase the issue branch onto the verified base when safe
+     - Stop on conflict, changed remote tip, or lease failure
      - Skip to step (e)
 
 c. **Create the worktree:**
    - Determine branch name: `squad/{issue-number}-{kebab-case-slug}` (derive slug from issue title if available)
-   - Determine base branch (typically `main`, check default branch if needed)
-   - Run: `git worktree add {path} -b {branch} {baseBranch}`
-   - Example: `git worktree add C:\src\squad-42 -b squad/42-fix-login main`
+   - Determine base branch: live `origin/main` for independent work, or the
+     verified remote parent branch for a stacked dependency
+   - Run: `git fetch --prune origin` followed by
+     `git worktree add {path} -b {branch} {verifiedRemoteBase}`
+   - Example: `git worktree add C:\src\squad-42 -b squad/42-fix-login origin/main`
 
 d. **Set up dependencies:**
    - Link `node_modules` from main repo to avoid reinstalling:
@@ -118,6 +128,7 @@ d. **Set up dependencies:**
 e. **Include worktree context in spawn:**
    - Set `WORKTREE_PATH` to the resolved worktree path
    - Set `WORKTREE_MODE` to `true`
+   - Set `BASE_REF` and `BASE_SHA` to the verified remote base
    - Add worktree instructions to the spawn prompt (see template below)
 
 **3. If worktrees disabled:**


### PR DESCRIPTION
## Why

Squad sub-sessions must start from current code, preserve parent execution quality, and prove changes locally before asking reviewers to merge them.

## Approach

- Defaults App sub-sessions to the `Squad` custom agent.
- Inherits parent model, context tier, reasoning effort, and mode when supported, with explicit fallbacks.
- Adds clean fetch/prune/rebase preflight against live `origin/main` or the verified stacked parent.
- Stops on dirty worktrees, conflicts, changed remote tips, or lease failures.
- Requires applicable local build/test/lint/type/docs/config/scenario checks and evidence before PR creation/readiness.
- Replaces the generic dev-first workflow skill with Andreja's `main` + isolated worktree + stacked-PR workflow.
- Keeps active and installed template copies synchronized.

## Validation

- `squad doctor`: 11 passed, 0 failed, 0 warnings
- Active/template workflow skills have identical hashes
- YAML parses successfully
- `git diff --check` passes
- Focused code review completed; two stale `general-purpose` hardcodes were fixed

## Stack

Depends on the Andreja Squad foundation PR and targets its branch.

Closes #22