### PR TITLE
docs: clarify charter ratification status

### DIFF
--- a/.github/ISSUE_TEMPLATE/decision.yml
+++ b/.github/ISSUE_TEMPLATE/decision.yml
@@ -37,9 +37,7 @@ body:
     id: charter
     attributes:
       label: Charter, ethics, and sustainability impact
-      description: Assess the people, agency, data, inclusion, AI and safety, sustainability, stakeholder incentives, evidence, ownership, and stop conditions required by docs/charter.md.
-    validations:
-      required: true
+      description: Optional until Cyrus explicitly ratifies docs/charter.md. Until then, use the Andreja company charter seed summary in docs/plan.md; after ratification, assess the people, agency, data, inclusion, AI and safety, sustainability, stakeholder incentives, evidence, ownership, and stop conditions required by docs/charter.md.
   - type: textarea
     id: stop
     attributes:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 Andreja is a user-owned personal assistant and skill platform. The ratified
 architecture, product roadmap, and delivery phases are in
-[`docs/plan.md`](docs/plan.md). The durable company mission, commitments, and
-operating culture are in [`docs/charter.md`](docs/charter.md).
+[`docs/plan.md`](docs/plan.md). The proposed company mission, commitments, and
+operating culture are in [`docs/charter.md`](docs/charter.md); the charter remains
+pending explicit ratification and takes effect only if Cyrus approves it.
 
 ## Development
 

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -1,6 +1,6 @@
 # Andreja company charter
 
-- **Status:** Proposed for explicit ratification
+- **Status:** Proposed for explicit ratification; not yet authoritative
 - **Final human authority:** Cyrus Jamula
 - **Tracking:** [GitHub issue #3](https://github.com/cyrusjamula/Andreja/issues/3)
 - **Governing context:** [Andreja platform plan](plan.md) and
@@ -8,7 +8,10 @@
 
 This charter governs Andreja's company, platform, products, brand, marketplace,
 Customer Zero operations, staff, contributors, agents, sponsors, and partners.
-It becomes effective only when Cyrus explicitly ratifies it.
+It becomes effective and is the authoritative charter only when Cyrus explicitly
+ratifies it. Until then, the `docs/plan.md` charter section is the seed summary;
+after ratification, that summary will be reconciled with this authoritative file
+in the next plan amendment.
 
 ## Mission
 
@@ -78,13 +81,15 @@ Andreja turns these commitments into daily behavior:
 ### Source and attribution posture
 
 This culture adapts broad ideas associated with
-[Amazon's Leadership Principles](https://www.amazon.jobs/en/principles), such as
-customer focus, ownership, learning, high standards, and long-term
+[Amazon's Leadership
+Principles](https://www.amazon.jobs/content/en/our-workplace/leadership-principles),
+such as customer focus, ownership, learning, high standards, and long-term
 responsibility, and with
-[Microsoft's culture](https://careers.microsoft.com/v2/global/en/culture) and
-[Responsible AI approach](https://www.microsoft.com/en-us/ai/responsible-ai),
-such as growth mindset, empowerment, inclusion, transparency, and
-accountability.
+[Microsoft's mission](https://www.microsoft.com/en-us/about),
+[culture](https://careers.microsoft.com/v2/global/en/culture), and
+[AI principles and
+approach](https://www.microsoft.com/en-us/ai/principles-and-approach), such as
+growth mindset, empowerment, inclusion, transparency, and accountability.
 
 Andreja expresses those influences in original language and adds its own
 requirements for user ownership, data dignity, consent, portability, ethical
@@ -225,3 +230,7 @@ without re-ratification when they do not change meaning.
 Public publication remains blocked until Sarek reviews attribution, trademark,
 reporting, and legal posture. That review informs publication language; it does
 not weaken the commitments in this private-facing charter.
+
+Any repository visibility change requires renewed Sarek review of official-source
+attribution, trademark posture, internal Star Trek codenames, and public-culture
+wording before the visibility change or publication proceeds.


### PR DESCRIPTION
## Why

Relates to #3.

PR #15 left cross-document ambiguity about whether the proposed charter was already effective and how its seed in the ratified plan should be handled. This follow-up makes the ratification boundary and publication gates explicit without amending the plan or claiming ratification.

## Approach

- Define `docs/charter.md` as authoritative only after Cyrus explicitly ratifies it, with the plan section retained as the seed summary until the next plan amendment.
- Mark the README charter description as proposed and pending approval.
- Make the decision-template charter-impact response optional until ratification and direct reviewers to the plan seed meanwhile.
- Align Amazon and Microsoft links with the plan's official sources.
- Require renewed Sarek review of internal Star Trek codenames and public-culture wording when repository visibility changes.

## Charter impact

This is a governance-coherence clarification. It preserves Cyrus's ratification authority, avoids treating a proposed charter as binding, keeps existing ethical and sustainability commitments unchanged, and adds a publication stop condition for visibility changes. No product data, runtime behavior, spending, or infrastructure is affected.

## Validation

- `python -c "import yaml,..."` — parsed `.github/ISSUE_TEMPLATE/decision.yml`; 7 body entries.
- `ConvertFrom-Markdown -Path README.md` and `ConvertFrom-Markdown -Path docs/charter.md` — both parsed; 16,195 generated HTML characters.
- Local Python Markdown-link check — all local links in changed Markdown resolve.
- `curl.exe -L` — Amazon and three Microsoft official source URLs returned HTTP 200.
- `git diff --check` — passed.
- `git diff --exit-code origin/main -- docs/plan.md` — passed; plan unchanged.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A. Independent follow-up to merged PR #15, targeting `main`.