### PR TITLE
Harden Squad security templates

### DIFF
--- a/.squad/templates/skills/distributed-mesh/sync-mesh.sh
+++ b/.squad/templates/skills/distributed-mesh/sync-mesh.sh
@@ -91,13 +91,15 @@ for squad in $(jq -r '.squads | to_entries[] | select(.value.zone == "remote-opa
   auth=$(jq -r ".squads.\"$squad\".auth // \"\"" "$MESH_JSON")
 
   mkdir -p "$target"
-  auth_flag=""
+  auth_args=()
   if [ "$auth" = "bearer" ]; then
     token_var="$(echo "${squad}" | tr '[:lower:]-' '[:upper:]_')_TOKEN"
-    [ -n "${!token_var:-}" ] && auth_flag="--header \"Authorization: Bearer ${!token_var}\""
+    if [ -n "${!token_var:-}" ]; then
+      auth_args=(--header "Authorization: Bearer ${!token_var}")
+    fi
   fi
 
-  eval curl --silent --fail $auth_flag "$source" -o "$target/SUMMARY.md" 2>/dev/null \
+  curl --silent --fail "${auth_args[@]}" "$source" -o "$target/SUMMARY.md" 2>/dev/null \
     || echo "# ${squad} — unavailable ($(date))" > "$target/SUMMARY.md"
 done
 

--- a/.squad/templates/skills/github-multi-account/SKILL.md
+++ b/.squad/templates/skills/github-multi-account/SKILL.md
@@ -15,7 +15,7 @@ When the user has multiple GitHub accounts (check with `gh auth status`). If you
 
 ### Step 1: Detect accounts
 Run: `gh auth status`
-Look for multiple accounts. Note which usernames are listed.
+Look for multiple accounts. Note only the usernames listed. Never request, query, log, or display account email addresses.
 
 ### Step 2: Ask the user
 Ask: "I see you have multiple GitHub accounts: {list them}. Which one is your personal account and which is your work/EMU account?"
@@ -24,9 +24,15 @@ Ask: "I see you have multiple GitHub accounts: {list them}. Which one is your pe
 Once the user confirms, do ALL of this for them:
 
 ```powershell
-# 1. Define the functions
-$personal = "THEIR_PERSONAL_USERNAME"
-$work = "THEIR_WORK_USERNAME"
+# 1. Use only the account logins the user explicitly confirmed
+$personalAccount = "USER_CONFIRMED_PERSONAL_LOGIN"
+$workAccount = "USER_CONFIRMED_WORK_LOGIN"
+
+foreach ($account in @($personalAccount, $workAccount)) {
+    if ($account -notmatch '^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$') {
+        throw "Invalid GitHub account login."
+    }
+}
 
 # 2. Add to PowerShell profile
 $profilePath = $PROFILE.CurrentUserAllHosts
@@ -36,8 +42,8 @@ if ($existing -notmatch "gh-personal") {
     $block = @"
 
 # === GitHub Multi-Account Aliases ===
-function gh-personal { gh auth switch --user $personal 2>`$null | Out-Null; gh @args }
-function gh-work { gh auth switch --user $work 2>`$null | Out-Null; gh @args }
+function gh-personal { gh auth switch --user '$personalAccount' 2>`$null | Out-Null; gh @args }
+function gh-work { gh auth switch --user '$workAccount' 2>`$null | Out-Null; gh @args }
 Set-Alias ghp gh-personal
 Set-Alias ghw gh-work
 "@
@@ -47,8 +53,8 @@ Set-Alias ghw gh-work
 # 3. Create CMD wrappers
 $binDir = Join-Path $env:USERPROFILE ".squad\bin"
 if (!(Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
-"@echo off`ngh auth switch --user $personal >nul 2>&1`ngh %*" | Out-File "$binDir\ghp.cmd" -Encoding ascii
-"@echo off`ngh auth switch --user $work >nul 2>&1`ngh %*" | Out-File "$binDir\ghw.cmd" -Encoding ascii
+"@echo off`ngh auth switch --user `"$personalAccount`" >nul 2>&1`ngh %*" | Out-File "$binDir\ghp.cmd" -Encoding ascii
+"@echo off`ngh auth switch --user `"$workAccount`" >nul 2>&1`ngh %*" | Out-File "$binDir\ghw.cmd" -Encoding ascii
 
 # 4. Add to PATH
 $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
@@ -58,8 +64,8 @@ if ($userPath -notmatch [regex]::Escape($binDir)) {
 }
 
 # 5. Load in current session
-function gh-personal { gh auth switch --user $personal 2>$null | Out-Null; gh @args }
-function gh-work { gh auth switch --user $work 2>$null | Out-Null; gh @args }
+function gh-personal { gh auth switch --user $personalAccount 2>$null | Out-Null; gh @args }
+function gh-work { gh auth switch --user $workAccount 2>$null | Out-Null; gh @args }
 Set-Alias ghp gh-personal
 Set-Alias ghw gh-work
 ```
@@ -78,18 +84,41 @@ ghw api user --jq '.login'   # should show work username
 
 1. **NEVER** use bare `gh` for repo operations — always `ghp` or `ghw`
 2. **NEVER** manually `gh auth switch` — the aliases handle it
-3. Determine alias by repo owner:
-   - Personal account repos → `ghp` / `gh-personal`
-   - Work/EMU account repos → `ghw` / `gh-work`
+3. Derive the current repository owner from the Git remote. Treat the remote as data and accept only recognized GitHub URL forms:
 
-## Repo-Specific Account Binding
+```powershell
+$remoteUrl = (git remote get-url origin).Trim()
+if ($LASTEXITCODE -ne 0) { throw "Unable to read the origin remote." }
 
-This repo (`bradygaster/squad`) is bound to the **bradygaster** (personal) account.
-All `gh` operations in this repo MUST use `ghp` / `gh-personal`.
+$ownerMatch = [regex]::Match(
+    $remoteUrl,
+    '^(?:https://[^/]+/|ssh://git@[^/]+/|git@[^:]+:)(?<owner>[A-Za-z0-9_.-]+)/[^/]+(?:\.git)?$'
+)
+if (!$ownerMatch.Success) { throw "Unsupported GitHub origin URL." }
+$repoOwner = $ownerMatch.Groups['owner'].Value
+```
+
+4. Ask the user whether `$repoOwner` must use the confirmed personal or work account. Do not infer the account for an organization owner. Store the answer using the already confirmed account variables:
+
+```powershell
+$confirmedRepoAccount = Read-Host "Use personal or work account for '$repoOwner'?"
+$accountByOwner = @{}
+switch ($confirmedRepoAccount.ToLowerInvariant()) {
+    "personal" { $accountByOwner[$repoOwner] = $personalAccount }
+    "work" { $accountByOwner[$repoOwner] = $workAccount }
+    default { throw "Choose personal or work." }
+}
+```
+
+Use `ghp` only when the mapped value equals `$personalAccount`; use `ghw` only when it equals `$workAccount`. Repeat the confirmation for an unmapped owner.
 
 ## For Squad Agents
-At the TOP of any script touching GitHub, define:
+At the top of any script touching GitHub, use the user-confirmed account variables; never embed account names or derive identity from email:
+
 ```powershell
-function gh-personal { gh auth switch --user bradygaster 2>$null | Out-Null; gh @args }
-function gh-work { gh auth switch --user bradyg_microsoft 2>$null | Out-Null; gh @args }
+if ([string]::IsNullOrWhiteSpace($personalAccount) -or [string]::IsNullOrWhiteSpace($workAccount)) {
+    throw "User-confirmed GitHub account variables are required."
+}
+function gh-personal { gh auth switch --user $personalAccount 2>$null | Out-Null; gh @args }
+function gh-work { gh auth switch --user $workAccount 2>$null | Out-Null; gh @args }
 ```


### PR DESCRIPTION
## Summary
- replace assembled/evaluated `curl` with a Bash argument array and direct invocation
- remove embedded GitHub identities and repository binding; derive the remote owner and require user-confirmed account mappings
- prohibit reading or displaying account email addresses
- confirm no active installed copies of either skill exist in this repository

## Validation
- `bash -n .squad/templates/skills/distributed-mesh/sync-mesh.sh`
- static checks: no `eval curl`; no `bradygaster` / `bradyg_microsoft` in the multi-account skill
- PowerShell parser: all 5 fenced examples parse successfully
- `git diff --check origin/main...HEAD`
- `squad doctor`: 8 passed, 2 failed, 1 warning, 2 info; pre-existing worktree/runtime findings are missing `decisions.md`, missing local sync hooks, and unavailable Copilot CLI

Closes #29