### PR TITLE
Migrate repository ownership to Jamula

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Private security reporting
-    url: https://github.com/cyrusjamula/Andreja/security/policy
+    url: https://github.com/Jamula/Andreja/security/policy
     about: Report vulnerabilities or data incidents privately.

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
@@ -51,7 +51,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -103,7 +103,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +112,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -14,10 +14,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -51,8 +51,8 @@
 ## Project Context
 
 - **Project:** Andreja
-- **Owner:** Cyrus Jamula
-- **Repository:** `cyrusjamula/Andreja`
+- **Owner:** Jamula organization (human steward: Cyrus Jamula)
+- **Repository:** `Jamula/Andreja`
 - **Stack:** .NET 10, Blazor, PostgreSQL reference persistence, OCI/OpenTofu portability
 - **Workflow:** GitHub Issues, protected-main target, one issue/branch/worktree/agent, stacked PRs for dependent slices
 - **Created:** 2026-08-23

--- a/.squad/templates/workflows/squad-ci.yml
+++ b/.squad/templates/workflows/squad-ci.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 

--- a/.squad/templates/workflows/squad-docs.yml
+++ b/.squad/templates/workflows/squad-docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: npm
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.squad/templates/workflows/squad-heartbeat.yml
+++ b/.squad/templates/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
@@ -51,7 +51,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -103,7 +103,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.squad/templates/workflows/squad-insider-release.yml
+++ b/.squad/templates/workflows/squad-insider-release.yml
@@ -11,11 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 

--- a/.squad/templates/workflows/squad-issue-assign.yml
+++ b/.squad/templates/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +112,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.squad/templates/workflows/squad-label-enforce.yml
+++ b/.squad/templates/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.squad/templates/workflows/squad-preview.yml
+++ b/.squad/templates/workflows/squad-preview.yml
@@ -11,9 +11,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 

--- a/.squad/templates/workflows/squad-promote.yml
+++ b/.squad/templates/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.squad/templates/workflows/squad-release.yml
+++ b/.squad/templates/workflows/squad-release.yml
@@ -11,11 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 

--- a/.squad/templates/workflows/squad-triage.yml
+++ b/.squad/templates/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.squad/templates/workflows/sync-squad-labels.yml
+++ b/.squad/templates/workflows/sync-squad-labels.yml
@@ -14,10 +14,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/docs/adr/0000-plan-ratification.md
+++ b/docs/adr/0000-plan-ratification.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-08-23
 - **Approver:** Cyrus Jamula
 - **Plan:** [`docs/plan.md`](../plan.md)
-- **Plan SHA-256:** `073f928ddbfc8c8fbf837897e5e9473296b32dba1b571fc921be4b10d1401448`
+- **Plan SHA-256:** `9dfe3e8f81d140082270de0517ecc3f15d2a2090c5b6c530f83fe461ff8798c0`
 
 ## Decision
 
@@ -40,3 +40,15 @@ Changes to vision, data ownership, trust boundaries, the Phase 0 envelope,
 public claims, legal posture, or non-negotiable architecture require explicit
 re-ratification. Documentation CI must fail when this ADR's current hash does
 not match the merged `docs/plan.md`.
+
+## Amendments
+
+### 2026-08-23 — organization repository migration
+
+- **Tracking issue:** [#30](https://github.com/Jamula/Andreja/issues/30)
+- **Pull request:** Pending
+- **Plan SHA-256:** `9dfe3e8f81d140082270de0517ecc3f15d2a2090c5b6c530f83fe461ff8798c0`
+- **Approver:** Cyrus Jamula
+- **Decision:** Logged amendment; no architecture or ratification change.
+- **Scope:** Update the canonical repository and organization Project references
+  after transfer to `Jamula/Andreja`.

--- a/docs/adr/0000-plan-ratification.md
+++ b/docs/adr/0000-plan-ratification.md
@@ -46,7 +46,7 @@ not match the merged `docs/plan.md`.
 ### 2026-08-23 — organization repository migration
 
 - **Tracking issue:** [#30](https://github.com/Jamula/Andreja/issues/30)
-- **Pull request:** Pending
+- **Pull request:** [#34](https://github.com/Jamula/Andreja/pull/34)
 - **Plan SHA-256:** `9dfe3e8f81d140082270de0517ecc3f15d2a2090c5b6c530f83fe461ff8798c0`
 - **Approver:** Cyrus Jamula
 - **Decision:** Logged amendment; no architecture or ratification change.

--- a/docs/business/sponsorship-policy.md
+++ b/docs/business/sponsorship-policy.md
@@ -5,8 +5,8 @@
 - **Owner:** Quark (financial terms) drafts with Sarek (terms/licensing), Deanna
   Troi (privacy/trust), Tuvok (integration security), and Neelix (public
   communication) reviewing; Cyrus approves
-- **Issue:** [#11 - Establish burn, usage, and sponsorship controls](https://github.com/cyrusjamula/Andreja/issues/11)
-- **Milestone:** [Phase 0 - Govern and decide](https://github.com/cyrusjamula/Andreja/milestone/1)
+- **Issue:** [#11 - Establish burn, usage, and sponsorship controls](https://github.com/Jamula/Andreja/issues/11)
+- **Milestone:** [Phase 0 - Govern and decide](https://github.com/Jamula/Andreja/milestone/1)
 - **Depends on / referenced by:** [`docs/plan.md`](../plan.md) (`### Initial
   sustainability model`, `## Public website, help, and support`),
   [`docs/adr/0000-plan-ratification.md`](../adr/0000-plan-ratification.md),

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed for explicit ratification; not yet authoritative
 - **Final human authority:** Cyrus Jamula
-- **Tracking:** [GitHub issue #3](https://github.com/cyrusjamula/Andreja/issues/3)
+- **Tracking:** [GitHub issue #3](https://github.com/Jamula/Andreja/issues/3)
 - **Governing context:** [Andreja platform plan](plan.md) and
   [ADR 0000](adr/0000-plan-ratification.md)
 

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -2,8 +2,8 @@
 
 - **Status:** Draft for ratification
 - **Owner:** Quark (CFO, FinOps and Sustainability Lead)
-- **Issue:** [#11 - Establish burn, usage, and sponsorship controls](https://github.com/cyrusjamula/Andreja/issues/11)
-- **Milestone:** [Phase 0 - Govern and decide](https://github.com/cyrusjamula/Andreja/milestone/1)
+- **Issue:** [#11 - Establish burn, usage, and sponsorship controls](https://github.com/Jamula/Andreja/issues/11)
+- **Milestone:** [Phase 0 - Govern and decide](https://github.com/Jamula/Andreja/milestone/1)
 - **Depends on / referenced by:** [`docs/plan.md`](plan.md) (`## Cost and FinOps`,
   `### Initial sustainability model`, `## Documentation structure`),
   [`docs/adr/0000-plan-ratification.md`](adr/0000-plan-ratification.md),

--- a/docs/frameworks/feedback-support.md
+++ b/docs/frameworks/feedback-support.md
@@ -394,6 +394,12 @@ The user chooses no follow-up or an approved channel. Messages:
 
 Publication is optional and never required to receive support.
 
+The configurable publication target defaults to `Jamula/Andreja`. Implementations
+must accept the repository owner and name through deployment configuration rather
+than compile a personal account into the publisher. An override must identify an
+approved repository with equivalent privacy, security, and retention controls;
+tests must cover both the canonical default and an override.
+
 1. Complete privacy screening, private incident routing, and dedupe.
 2. Create a sanitized draft containing only the proposed title, body, labels,
    acceptance evidence, and safe source reference.

--- a/docs/legal/license-evaluation.md
+++ b/docs/legal/license-evaluation.md
@@ -55,7 +55,7 @@ The following are point-in-time technical observations, not legal conclusions:
 
 | Fact as of 2026-08-23 | Evidence |
 |---|---|
-| GitHub reports `cyrusjamula/Andreja` as a private personal-account repository created 2026-08-22. | GitHub repository API |
+| GitHub reported the predecessor repository under Cyrus Jamula's personal account as private and created 2026-08-22; the canonical repository is now `Jamula/Andreja`. | GitHub repository API |
 | GitHub identifies the repository license as Apache-2.0. | GitHub repository API and root `LICENSE` |
 | The complete Apache License 2.0 text has been present since the initial commit. | Commit `3f576b3ac4418e9975d858e303094e24672aacda`; `LICENSE` SHA-256 `c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4` |
 | The evaluated branch head was `a875f926095b3194a92e06b86b0d15dfaa0a2d7a`, with seven commits and one human Git author identity. | Local Git history at preparation time |

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -2,8 +2,8 @@
 
 - **Status:** Draft for ratification
 - **Owner:** Picard (CEO and Lead/Captain), with Quark (CFO/FinOps)
-- **Issue:** [#14 - Ratify cohesive workstreams and MVP operating model](https://github.com/cyrusjamula/Andreja/issues/14)
-- **Milestone:** [Phase 0 - Govern and decide](https://github.com/cyrusjamula/Andreja/milestone/1)
+- **Issue:** [#14 - Ratify cohesive workstreams and MVP operating model](https://github.com/Jamula/Andreja/issues/14)
+- **Milestone:** [Phase 0 - Govern and decide](https://github.com/Jamula/Andreja/milestone/1)
 - **Depends on / referenced by:** [`docs/plan.md`](plan.md) (`## Operating model and cohesive workstreams`,
   `## Roadmap prioritization and launch framework`, `## Phased execution`),
   [`docs/charter.md`](charter.md), [`docs/adr/0000-plan-ratification.md`](adr/0000-plan-ratification.md),
@@ -22,7 +22,7 @@ and stop/de-scope rules, and executive-versus-Cyrus authority.
 It is explicitly **not authoritative** for, and does not define or duplicate,
 scoring, sequencing, or launch: the issue scorecard, portfolio lanes,
 Must/Should/Could/Won't stage scope, and launch-stage evidence gates remain owned
-by [issue #5](https://github.com/cyrusjamula/Andreja/issues/5) and its ratified
+by [issue #5](https://github.com/Jamula/Andreja/issues/5) and its ratified
 `docs/frameworks/prioritization-launch.md` (see `docs/plan.md`
 `## Roadmap prioritization and launch framework`). Where the two documents
 describe the same workstream, issue #5's ratified framework is authoritative for
@@ -42,7 +42,7 @@ and executive-versus-Cyrus authority.
 
 It does **not** define or duplicate the issue scorecard, portfolio lanes,
 Must/Should/Could/Won't stage scope, or launch-stage evidence gates. Those are owned
-by [issue #5](https://github.com/cyrusjamula/Andreja/issues/5) and live in
+by [issue #5](https://github.com/Jamula/Andreja/issues/5) and live in
 `docs/frameworks/prioritization-launch.md` once ratified (see `docs/plan.md`
 `## Roadmap prioritization and launch framework`). This document references that
 framework by name and label (`type:decision` + `area:product` issues that ratify
@@ -54,7 +54,7 @@ weights, lanes, or gate checklists.
 | Domain | Source of truth | Owner |
 |---|---|---|
 | Architecture, roadmap, phased scope | [`docs/plan.md`](plan.md) and accepted ADRs (`docs/adr/`) | Spock (architecture); Picard (roadmap) |
-| Execution state (what's being worked, by whom, when done) | GitHub Issues and milestones in `cyrusjamula/Andreja` | Coordinator (Squad) |
+| Execution state (what's being worked, by whom, when done) | GitHub Issues and milestones in `Jamula/Andreja` | Coordinator (Squad) |
 | Prioritization, scoring, launch-stage gates | `docs/frameworks/prioritization-launch.md` (issue #5) | Picard/Quark |
 | Charters, routing, ceremonies, non-negotiable directives | `.squad/directives.md`, `.squad/team.md`, `.squad/routing.md`, `.squad/ceremonies.md`, `.squad/agents/*/charter.md` | Coordinator (Squad) |
 | Who owns which work right now | This document's workstream table + `squad:{member}` / `area:*` labels | Picard (triage) |
@@ -258,9 +258,9 @@ creating a second backlog; Scribe logs automatically and never blocks.
   separate budget approval and Phase 1A's exit checklist is proven; it adds the
   managed deployment, public site, feedback intake, and the first managed
   dogfood cohort without touching Phase 1A's invariants.
-- Milestone mapping: `phase:0` -> [milestone #1](https://github.com/cyrusjamula/Andreja/milestone/1);
-  Phase 1A -> [milestone #2](https://github.com/cyrusjamula/Andreja/milestone/2);
-  Phase 1B -> [milestone #3](https://github.com/cyrusjamula/Andreja/milestone/3).
+- Milestone mapping: `phase:0` -> [milestone #1](https://github.com/Jamula/Andreja/milestone/1);
+  Phase 1A -> [milestone #2](https://github.com/Jamula/Andreja/milestone/2);
+  Phase 1B -> [milestone #3](https://github.com/Jamula/Andreja/milestone/3).
   Later phases (`4`-`15`) exist as milestones today and are sequenced, not
   reordered, except through an issue + ADR/plan update that preserves
   dependencies and user-data guarantees.
@@ -321,7 +321,7 @@ creating a second backlog; Scribe logs automatically and never blocks.
 - **Quark (CFO) — ledger and spend path:** Quark owns the financial-controls
   source of truth (burn/income ledger, budgets, forecast/runway, unit
   economics — `docs/plan.md` `## Cost and FinOps`; durable artifact pending
-  ratification under [issue #11](https://github.com/cyrusjamula/Andreja/issues/11)
+  ratification under [issue #11](https://github.com/Jamula/Andreja/issues/11)
   as `docs/cost-model.md` and `docs/business/sponsorship-policy.md`). Quark
   facilitates the per-session Session Close Efficiency Review ledger entry
   (below) and posts aggregate findings to the relevant FinOps/retrospective

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -845,11 +845,12 @@ The approved implementation creates:
 - `docs/legal/regulatory-applicability.md`: Sarek's jurisdiction/capability applicability and horizon register with counsel decisions.
 - `docs/business/sponsorship-policy.md`: eligibility, disclosures, recognition, conflicts, independence, termination and prohibited sponsors.
 - `docs/marketplace/governance.md`: publisher/user rights, review/ranking/appeal, portability, commercial and trust rules.
+- `docs/repository-migration.md`: canonical repository ownership, roadmap Project, migration checks, and operations follow-ups.
 
 ## GitHub project management
 
-- Keep planning repository-native for now: Issues, milestones, labels, issue forms, pull requests, and repository automation all live in `cyrusjamula/Andreja`.
-- Defer a GitHub Project board until the repository moves into an organization. Then create an organization-owned Project and add the existing repository issues without changing their canonical home.
+- Keep planning repository-native: Issues, milestones, labels, issue forms, pull requests, and repository automation all live in `Jamula/Andreja`.
+- Use the organization-owned [Andreja Roadmap](https://github.com/orgs/Jamula/projects/2) Project for portfolio views. Repository issues remain canonical, milestones represent delivery phases, and the Project exposes only useful built-in planning fields.
 - Create one roadmap/epic issue that links `docs/plan.md`, every phase milestone, open ADR decision, and the current risk register.
 - Represent each delivery phase as a GitHub milestone with an explicit exit-gate issue.
 - Convert the tracking todos into scoped GitHub Issues with:

--- a/docs/repository-migration.md
+++ b/docs/repository-migration.md
@@ -3,7 +3,7 @@
 - **Tracking:** [GitHub issue #30](https://github.com/Jamula/Andreja/issues/30)
 - **Canonical repository:** [`Jamula/Andreja`](https://github.com/Jamula/Andreja)
 - **Organization Project:** [Andreja Roadmap](https://github.com/orgs/Jamula/projects/2)
-- **Verified base:** `90970550414279d341f4362f572faec8564b5743`
+- **Verified base:** `d52badda75e2b9c1289d482709d2915cb1d52a52`
 - **Review date:** 2026-08-23
 
 `Jamula/Andreja` is the source of truth. Supported workflows must not depend on

--- a/docs/repository-migration.md
+++ b/docs/repository-migration.md
@@ -1,0 +1,43 @@
+# Repository organization migration
+
+- **Tracking:** [GitHub issue #30](https://github.com/Jamula/Andreja/issues/30)
+- **Canonical repository:** [`Jamula/Andreja`](https://github.com/Jamula/Andreja)
+- **Organization Project:** [Andreja Roadmap](https://github.com/orgs/Jamula/projects/2)
+- **Verified base:** `90970550414279d341f4362f572faec8564b5743`
+- **Review date:** 2026-08-23
+
+`Jamula/Andreja` is the source of truth. Supported workflows must not depend on
+the former personal-account repository or its redirect.
+
+## Repository and planning state
+
+- The local `origin` fetch and push URL resolves directly to
+  `https://github.com/Jamula/Andreja.git`; the default branch is `main`.
+- The organization-owned Andreja Roadmap Project contains all 14 repository
+  issues. Its built-in Status, Milestone, Labels, Assignees, Repository, linked
+  pull request, parent issue, and date fields avoid duplicating issue metadata.
+- All 15 phase milestones remain repository-owned and appear through each
+  Project item's Milestone field. GitHub Projects do not add milestones as
+  standalone items.
+- `cyrusjamula` in `.github/FUNDING.yml` is intentionally the GitHub Sponsors
+  profile, not a repository owner or route.
+
+## Migration impact review
+
+| Area | Verified state and required follow-up |
+|---|---|
+| Actions | Actions are enabled, all actions are allowed, and SHA pinning is required. Workflows use repository context and contain no former-owner route. Keep reusable workflow references and permissions organization-safe. |
+| Branch rules and stacks | Two active repository rulesets protect policy and branch behavior. The repository allows squash merge only and deletes merged branches. Stacked work continues to target `main`; branch and PR links must use the canonical repository. |
+| Security | Code security, Dependabot security updates, secret scanning, validity checks, and push protection are enabled. The issue chooser now routes private reports to the canonical security policy. No secret value was read or changed. |
+| Billing | No billing setting, paid feature, visibility, or production resource was changed. An organization owner must review billing before enabling any paid feature; this migration does not authorize spend. |
+| OAuth and GitHub Apps | The organization reports the Azure Pipelines, Managed DevOps Pools, and Configure Azure Settings GitHub Apps as installed for all repositories. Their owners must verify callback URLs, webhook targets, and organization authorization in each provider console; no credential or installation was changed. |
+| Packages and containers | No committed package or container namespace names the former owner. Package inventory was not readable with the current token; an authorized owner can run `gh auth refresh -h github.com -s read:packages` and then `gh api "orgs/Jamula/packages?package_type=container"` to verify any existing `ghcr.io/jamula/*` namespace. |
+| Feedback | The documented publisher target defaults to `Jamula/Andreja` but remains deployment-configurable. Overrides require equivalent privacy and security controls. |
+| Federation and semantic namespaces | Repository links use the canonical owner. Durable protocol, identity, and semantic identifiers must remain product-owned and must not derive identity from a GitHub owner or redirect. |
+
+## Compatibility
+
+Historical references may describe the repository before transfer, but they are
+not supported configuration values. Do not add redirect-dependent examples,
+clone URLs, API endpoints, badges, callbacks, package coordinates, or issue
+targets.

--- a/docs/repository-migration.md
+++ b/docs/repository-migration.md
@@ -26,7 +26,7 @@ the former personal-account repository or its redirect.
 
 | Area | Verified state and required follow-up |
 |---|---|
-| Actions | Actions are enabled, all actions are allowed, and SHA pinning is required. Workflows use repository context and contain no former-owner route. Keep reusable workflow references and permissions organization-safe. |
+| Actions | Actions are enabled, all actions are allowed, and SHA pinning is required. Every external action in active workflows and installed Squad workflow templates is pinned to the official major-version tag's full commit SHA, with the readable version retained in a comment. Workflows use repository context and contain no former-owner route. |
 | Branch rules and stacks | Two active repository rulesets protect policy and branch behavior. The repository allows squash merge only and deletes merged branches. Stacked work continues to target `main`; branch and PR links must use the canonical repository. |
 | Security | Code security, Dependabot security updates, secret scanning, validity checks, and push protection are enabled. The issue chooser now routes private reports to the canonical security policy. No secret value was read or changed. |
 | Billing | No billing setting, paid feature, visibility, or production resource was changed. An organization owner must review billing before enabling any paid feature; this migration does not authorize spend. |

--- a/docs/semantic-graph.md
+++ b/docs/semantic-graph.md
@@ -3,7 +3,7 @@
 - **Status:** Decision recommendation; pending Seven, Spock, T'Pol, Deanna Troi,
   Tuvok, Data, and Cyrus review
 - **Prepared:** 2026-08-23
-- **Tracking:** [GitHub issue #4](https://github.com/cyrusjamula/Andreja/issues/4)
+- **Tracking:** [GitHub issue #4](https://github.com/Jamula/Andreja/issues/4)
 - **Governing sources:** [platform plan](plan.md),
   [company charter](charter.md), and
   [ADR 0000](adr/0000-plan-ratification.md)


### PR DESCRIPTION
## Summary
- make `Jamula/Andreja` canonical across committed repository links, Squad context, docs, and the configurable feedback publisher default
- pin every external action in active workflows and installed Squad workflow templates to the official major-version tag's full commit SHA, retaining readable version comments
- create and populate the organization-owned Andreja Roadmap Project with all 14 issues and milestone/status fields
- record the migration impact review for Actions, stacks, security, billing, OAuth/GitHub Apps, packages, feedback, and durable namespaces
- amend ADR 0000 with the canonical committed-format plan hash without changing architecture or ratification

## Validation
- official `python .github/scripts/check_docs_consistency.py` passed: plan hash plus 19-skill and 23-connector catalog consistency
- parsed all 16 active/template workflow YAML files and verified all 38 external `uses:` references are 40-character SHAs with version comments
- resolved all six pinned SHAs against official `actions/*` major-version tags through the GitHub API
- verified the workflow diffs change only `uses:` references; permissions and triggers are unchanged
- `docs/plan.md` committed-format SHA-256: `9dfe3e8f81d140082270de0517ecc3f15d2a2090c5b6c530f83fe461ff8798c0`
- 11 JSON and 23 YAML files parsed successfully
- local links in 18 documentation files and 9 canonical GitHub issue/milestone links passed; security policy source, Project, and PR resolved
- `git diff --check` and case-insensitive former-repository scan passed; the only `cyrusjamula` use is the intentional Sponsors profile plus its explanatory note
- `squad doctor`: 9 passed, 2 pre-existing local-state failures (`.squad/decisions.md` is intentionally ignored and two-layer sync hooks are not installed in this isolated worktree)

## Project and operational review
Andreja Roadmap: https://github.com/orgs/Jamula/projects/2

No secrets, visibility, licensing, billing, OAuth settings, app installations, or production resources were changed. Package inventory requires an additional `read:packages` scope; OAuth callback and billing verification remain explicit owner-console follow-ups in `docs/repository-migration.md`.

The post-push checks were rerun. GitHub accepted the updated workflows, but hosted jobs still cannot start: both runs report that recent account payments failed or the spending limit must be increased. Local YAML, immutable-pin, official-tag, and docs checks pass; no billing setting was changed.

Closes #30