### PR TITLE
Scaffold the .NET 10 modular foundation

### DIFF
--- a/Andreja.slnx
+++ b/Andreja.slnx
@@ -1,0 +1,17 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/Andreja.Api.Contracts/Andreja.Api.Contracts.csproj" />
+    <Project Path="src/Andreja.AppHost/Andreja.AppHost.csproj" />
+    <Project Path="src/Andreja.Platform.Contracts/Andreja.Platform.Contracts.csproj" />
+  </Folder>
+  <Folder Name="/src/Adapters/">
+    <Project Path="src/Adapters/Andreja.Adapters/Andreja.Adapters.csproj" />
+  </Folder>
+  <Folder Name="/src/Modules/">
+    <Project Path="src/Modules/Andreja.Modules/Andreja.Modules.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Andreja.ArchitectureTests/Andreja.ArchitectureTests.csproj" />
+    <Project Path="tests/Andreja.UnitTests/Andreja.UnitTests.csproj" />
+  </Folder>
+</Solution>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ pending explicit ratification and takes effect only if Cyrus approves it.
 - PostgreSQL is the Phase 1A self-hosted reference.
 - Squad coordinates the project through GitHub Issues and isolated worktrees.
 
+See [`docs/development.md`](docs/development.md) for the pinned SDK, solution
+layout, local validation commands, and foundation scope.
+
 Install Squad CLI 0.11.0 through an approved package source, then validate it:
 
 ```powershell

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,51 @@
+# Local development
+
+## Prerequisites
+
+- .NET SDK 10.0.301, pinned by `global.json`
+
+The foundation does not require cloud accounts, provider credentials, containers,
+or external services.
+
+## Solution layout
+
+- `src\Andreja.AppHost`: the composition root, minimal HTTP pipeline, and empty
+  Blazor host.
+- `src\Andreja.Api.Contracts`: the versioned HTTP contract boundary.
+- `src\Andreja.Platform.Contracts`: framework-neutral shared boundary contracts.
+- `src\Modules\Andreja.Modules`: capability seams for Identity, Open Loops,
+  Assistant, Skills, Channels, and Portability.
+- `src\Adapters\Andreja.Adapters`: outer seams for PostgreSQL, ASP.NET Core
+  Identity, OpenAI-compatible assistants, and OpenTelemetry.
+- `tests\Andreja.ArchitectureTests` and `tests\Andreja.UnitTests`: dependency
+  direction and unit baselines.
+
+Modules and adapters begin as one assembly each. They should split only when a
+real forbidden reference or adapter isolation requirement needs a compiler
+boundary, as required by ADR 0001.
+
+SDK analyzers, nullable reference types, warnings-as-errors, package versions,
+and deterministic compilation are configured centrally.
+
+## Validate
+
+Run these commands from the repository root:
+
+```powershell
+dotnet restore Andreja.slnx
+dotnet build Andreja.slnx --no-restore
+dotnet test Andreja.slnx --no-build
+dotnet format Andreja.slnx --verify-no-changes --no-restore
+```
+
+The architecture test project enforces inward dependency direction. The unit test
+project verifies composition-root registration and startup-options validation.
+
+## Run the empty host
+
+```powershell
+dotnet run --project src\Andreja.AppHost\Andreja.AppHost.csproj
+```
+
+This starts only the empty Blazor foundation host. Identity, persistence,
+assistant, tasks, containers, and provider integrations are intentionally absent.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "disable",
+    "allowPrerelease": false
+  }
+}

--- a/src/Adapters/Andreja.Adapters/Andreja.Adapters.csproj
+++ b/src/Adapters/Andreja.Adapters/Andreja.Adapters.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Andreja.Platform.Contracts\Andreja.Platform.Contracts.csproj" />
+    <ProjectReference Include="..\..\Modules\Andreja.Modules\Andreja.Modules.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Adapters/Andreja.Adapters/Assistant.OpenAiCompatible/OpenAiCompatibleAssistantAdapter.cs
+++ b/src/Adapters/Andreja.Adapters/Assistant.OpenAiCompatible/OpenAiCompatibleAssistantAdapter.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Adapters.Assistant.OpenAiCompatible;
+
+public sealed class OpenAiCompatibleAssistantAdapter : IAdapterBoundary;

--- a/src/Adapters/Andreja.Adapters/Identity.AspNetCore/AspNetCoreIdentityAdapter.cs
+++ b/src/Adapters/Andreja.Adapters/Identity.AspNetCore/AspNetCoreIdentityAdapter.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Adapters.Identity.AspNetCore;
+
+public sealed class AspNetCoreIdentityAdapter : IAdapterBoundary;

--- a/src/Adapters/Andreja.Adapters/OpenTelemetry/OpenTelemetryAdapter.cs
+++ b/src/Adapters/Andreja.Adapters/OpenTelemetry/OpenTelemetryAdapter.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Adapters.OpenTelemetry;
+
+public sealed class OpenTelemetryAdapter : IAdapterBoundary;

--- a/src/Adapters/Andreja.Adapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/src/Adapters/Andreja.Adapters/PostgreSql/PostgreSqlAdapter.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Adapters.PostgreSql;
+
+public sealed class PostgreSqlAdapter : IAdapterBoundary;

--- a/src/Andreja.Api.Contracts/Andreja.Api.Contracts.csproj
+++ b/src/Andreja.Api.Contracts/Andreja.Api.Contracts.csproj
@@ -1,0 +1,3 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/src/Andreja.Api.Contracts/ApiContractAssembly.cs
+++ b/src/Andreja.Api.Contracts/ApiContractAssembly.cs
@@ -1,0 +1,8 @@
+using System.Reflection;
+
+namespace Andreja.Api.Contracts;
+
+public static class ApiContractAssembly
+{
+    public static Assembly Reference => typeof(ApiContractAssembly).Assembly;
+}

--- a/src/Andreja.AppHost/Andreja.AppHost.csproj
+++ b/src/Andreja.AppHost/Andreja.AppHost.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Andreja.Api.Contracts\Andreja.Api.Contracts.csproj" />
+    <ProjectReference Include="..\Andreja.Platform.Contracts\Andreja.Platform.Contracts.csproj" />
+    <ProjectReference Include="..\Modules\Andreja.Modules\Andreja.Modules.csproj" />
+    <ProjectReference Include="..\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <NoDefaultLaunchSettingsFile>True</NoDefaultLaunchSettingsFile>
+    <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+  </PropertyGroup>
+
+</Project>

--- a/src/Andreja.AppHost/Components/App.razor
+++ b/src/Andreja.AppHost/Components/App.razor
@@ -1,0 +1,21 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <ResourcePreloader />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <link rel="stylesheet" href="@Assets["Andreja.AppHost.styles.css"]" />
+    <ImportMap />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes />
+    <ReconnectModal />
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+</body>
+
+</html>

--- a/src/Andreja.AppHost/Components/Layout/MainLayout.razor
+++ b/src/Andreja.AppHost/Components/Layout/MainLayout.razor
@@ -1,0 +1,9 @@
+﻿@inherits LayoutComponentBase
+
+@Body
+
+<div id="blazor-error-ui" data-nosnippet>
+    An unhandled error has occurred.
+    <a href="." class="reload">Reload</a>
+    <span class="dismiss">🗙</span>
+</div>

--- a/src/Andreja.AppHost/Components/Layout/MainLayout.razor.css
+++ b/src/Andreja.AppHost/Components/Layout/MainLayout.razor.css
@@ -1,0 +1,20 @@
+#blazor-error-ui {
+    color-scheme: light only;
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }

--- a/src/Andreja.AppHost/Components/Layout/ReconnectModal.razor
+++ b/src/Andreja.AppHost/Components/Layout/ReconnectModal.razor
@@ -1,0 +1,31 @@
+﻿<script type="module" src="@Assets["Components/Layout/ReconnectModal.razor.js"]"></script>
+
+<dialog id="components-reconnect-modal" data-nosnippet>
+    <div class="components-reconnect-container">
+        <div class="components-rejoining-animation" aria-hidden="true">
+            <div></div>
+            <div></div>
+        </div>
+        <p class="components-reconnect-first-attempt-visible">
+            Rejoining the server...
+        </p>
+        <p class="components-reconnect-repeated-attempt-visible">
+            Rejoin failed... trying again in <span id="components-seconds-to-next-attempt"></span> seconds.
+        </p>
+        <p class="components-reconnect-failed-visible">
+            Failed to rejoin.<br />Please retry or reload the page.
+        </p>
+        <button id="components-reconnect-button" class="components-reconnect-failed-visible">
+            Retry
+        </button>
+        <p class="components-pause-visible">
+            The session has been paused by the server.
+        </p>
+        <p class="components-resume-failed-visible">
+            Failed to resume the session.<br />Please retry or reload the page.
+        </p>
+        <button id="components-resume-button" class="components-pause-visible components-resume-failed-visible">
+            Resume
+        </button>
+    </div>
+</dialog>

--- a/src/Andreja.AppHost/Components/Layout/ReconnectModal.razor.css
+++ b/src/Andreja.AppHost/Components/Layout/ReconnectModal.razor.css
@@ -1,0 +1,157 @@
+.components-reconnect-first-attempt-visible,
+.components-reconnect-repeated-attempt-visible,
+.components-reconnect-failed-visible,
+.components-pause-visible,
+.components-resume-failed-visible,
+.components-rejoining-animation {
+    display: none;
+}
+
+#components-reconnect-modal.components-reconnect-show .components-reconnect-first-attempt-visible,
+#components-reconnect-modal.components-reconnect-show .components-rejoining-animation,
+#components-reconnect-modal.components-reconnect-paused .components-pause-visible,
+#components-reconnect-modal.components-reconnect-resume-failed .components-resume-failed-visible,
+#components-reconnect-modal.components-reconnect-retrying,
+#components-reconnect-modal.components-reconnect-retrying .components-reconnect-repeated-attempt-visible,
+#components-reconnect-modal.components-reconnect-retrying .components-rejoining-animation,
+#components-reconnect-modal.components-reconnect-failed,
+#components-reconnect-modal.components-reconnect-failed .components-reconnect-failed-visible {
+    display: block;
+}
+
+
+#components-reconnect-modal {
+    background-color: white;
+    width: 20rem;
+    margin: 20vh auto;
+    padding: 2rem;
+    border: 0;
+    border-radius: 0.5rem;
+    box-shadow: 0 3px 6px 2px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    transition: display 0.5s allow-discrete, overlay 0.5s allow-discrete;
+    animation: components-reconnect-modal-fadeOutOpacity 0.5s both;
+    &[open]
+
+{
+    animation: components-reconnect-modal-slideUp 1.5s cubic-bezier(.05, .89, .25, 1.02) 0.3s, components-reconnect-modal-fadeInOpacity 0.5s ease-in-out 0.3s;
+    animation-fill-mode: both;
+}
+
+}
+
+#components-reconnect-modal::backdrop {
+    background-color: rgba(0, 0, 0, 0.4);
+    animation: components-reconnect-modal-fadeInOpacity 0.5s ease-in-out;
+    opacity: 1;
+}
+
+@keyframes components-reconnect-modal-slideUp {
+    0% {
+        transform: translateY(30px) scale(0.95);
+    }
+
+    100% {
+        transform: translateY(0);
+    }
+}
+
+@keyframes components-reconnect-modal-fadeInOpacity {
+    0% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
+}
+
+@keyframes components-reconnect-modal-fadeOutOpacity {
+    0% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+    }
+}
+
+.components-reconnect-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+#components-reconnect-modal p {
+    margin: 0;
+    text-align: center;
+}
+
+#components-reconnect-modal button {
+    border: 0;
+    background-color: #6b9ed2;
+    color: white;
+    padding: 4px 24px;
+    border-radius: 4px;
+}
+
+    #components-reconnect-modal button:hover {
+        background-color: #3b6ea2;
+    }
+
+    #components-reconnect-modal button:active {
+        background-color: #6b9ed2;
+    }
+
+.components-rejoining-animation {
+    position: relative;
+    width: 80px;
+    height: 80px;
+}
+
+    .components-rejoining-animation div {
+        position: absolute;
+        border: 3px solid #0087ff;
+        opacity: 1;
+        border-radius: 50%;
+        animation: components-rejoining-animation 1.5s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+    }
+
+        .components-rejoining-animation div:nth-child(2) {
+            animation-delay: -0.5s;
+        }
+
+@keyframes components-rejoining-animation {
+    0% {
+        top: 40px;
+        left: 40px;
+        width: 0;
+        height: 0;
+        opacity: 0;
+    }
+
+    4.9% {
+        top: 40px;
+        left: 40px;
+        width: 0;
+        height: 0;
+        opacity: 0;
+    }
+
+    5% {
+        top: 40px;
+        left: 40px;
+        width: 0;
+        height: 0;
+        opacity: 1;
+    }
+
+    100% {
+        top: 0px;
+        left: 0px;
+        width: 80px;
+        height: 80px;
+        opacity: 0;
+    }
+}

--- a/src/Andreja.AppHost/Components/Layout/ReconnectModal.razor.js
+++ b/src/Andreja.AppHost/Components/Layout/ReconnectModal.razor.js
@@ -1,0 +1,63 @@
+// Set up event handlers
+const reconnectModal = document.getElementById("components-reconnect-modal");
+reconnectModal.addEventListener("components-reconnect-state-changed", handleReconnectStateChanged);
+
+const retryButton = document.getElementById("components-reconnect-button");
+retryButton.addEventListener("click", retry);
+
+const resumeButton = document.getElementById("components-resume-button");
+resumeButton.addEventListener("click", resume);
+
+function handleReconnectStateChanged(event) {
+    if (event.detail.state === "show") {
+        reconnectModal.showModal();
+    } else if (event.detail.state === "hide") {
+        reconnectModal.close();
+    } else if (event.detail.state === "failed") {
+        document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+    } else if (event.detail.state === "rejected") {
+        location.reload();
+    }
+}
+
+async function retry() {
+    document.removeEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+
+    try {
+        // Reconnect will asynchronously return:
+        // - true to mean success
+        // - false to mean we reached the server, but it rejected the connection (e.g., unknown circuit ID)
+        // - exception to mean we didn't reach the server (this can be sync or async)
+        const successful = await Blazor.reconnect();
+        if (!successful) {
+            // We have been able to reach the server, but the circuit is no longer available.
+            // We'll reload the page so the user can continue using the app as quickly as possible.
+            const resumeSuccessful = await Blazor.resumeCircuit();
+            if (!resumeSuccessful) {
+                location.reload();
+            } else {
+                reconnectModal.close();
+            }
+        }
+    } catch (err) {
+        // We got an exception, server is currently unavailable
+        document.addEventListener("visibilitychange", retryWhenDocumentBecomesVisible);
+    }
+}
+
+async function resume() {
+    try {
+        const successful = await Blazor.resumeCircuit();
+        if (!successful) {
+            location.reload();
+        }
+    } catch {
+        reconnectModal.classList.replace("components-reconnect-paused", "components-reconnect-resume-failed");
+    }
+}
+
+async function retryWhenDocumentBecomesVisible() {
+    if (document.visibilityState === "visible") {
+        await retry();
+    }
+}

--- a/src/Andreja.AppHost/Components/Pages/Error.razor
+++ b/src/Andreja.AppHost/Components/Pages/Error.razor
@@ -1,0 +1,36 @@
+﻿@page "/Error"
+@using System.Diagnostics
+
+<PageTitle>Error</PageTitle>
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>
+
+@code{
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    protected override void OnInitialized() =>
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+}

--- a/src/Andreja.AppHost/Components/Pages/Home.razor
+++ b/src/Andreja.AppHost/Components/Pages/Home.razor
@@ -1,0 +1,5 @@
+@page "/"
+
+<PageTitle>Andreja</PageTitle>
+
+<h1>Andreja</h1>

--- a/src/Andreja.AppHost/Components/Pages/NotFound.razor
+++ b/src/Andreja.AppHost/Components/Pages/NotFound.razor
@@ -1,0 +1,5 @@
+﻿@page "/not-found"
+@layout MainLayout
+
+<h3>Not Found</h3>
+<p>Sorry, the content you are looking for does not exist.</p>

--- a/src/Andreja.AppHost/Components/Routes.razor
+++ b/src/Andreja.AppHost/Components/Routes.razor
@@ -1,0 +1,6 @@
+﻿<Router AppAssembly="typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/Andreja.AppHost/Components/_Imports.razor
+++ b/src/Andreja.AppHost/Components/_Imports.razor
@@ -1,0 +1,11 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using Andreja.AppHost
+@using Andreja.AppHost.Components
+@using Andreja.AppHost.Components.Layout

--- a/src/Andreja.AppHost/Hosting/AndrejaHostOptions.cs
+++ b/src/Andreja.AppHost/Hosting/AndrejaHostOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Andreja.AppHost.Hosting;
+
+public sealed class AndrejaHostOptions
+{
+    public const string SectionName = "Andreja";
+
+    [Required]
+    public string InstanceName { get; init; } = string.Empty;
+}

--- a/src/Andreja.AppHost/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Andreja.AppHost/Hosting/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+using Andreja.Adapters.Assistant.OpenAiCompatible;
+using Andreja.Adapters.Identity.AspNetCore;
+using Andreja.Adapters.OpenTelemetry;
+using Andreja.Adapters.PostgreSql;
+using Andreja.Modules.Assistant;
+using Andreja.Modules.Channels;
+using Andreja.Modules.Identity;
+using Andreja.Modules.OpenLoops;
+using Andreja.Modules.Portability;
+using Andreja.Modules.Skills;
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.AppHost.Hosting;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddAndrejaFoundation(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<AndrejaHostOptions>()
+            .Bind(configuration.GetRequiredSection(AndrejaHostOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton<IModuleBoundary, IdentityModule>();
+        services.AddSingleton<IModuleBoundary, OpenLoopsModule>();
+        services.AddSingleton<IModuleBoundary, AssistantModule>();
+        services.AddSingleton<IModuleBoundary, SkillsModule>();
+        services.AddSingleton<IModuleBoundary, ChannelsModule>();
+        services.AddSingleton<IModuleBoundary, PortabilityModule>();
+
+        services.AddSingleton<IAdapterBoundary, PostgreSqlAdapter>();
+        services.AddSingleton<IAdapterBoundary, AspNetCoreIdentityAdapter>();
+        services.AddSingleton<IAdapterBoundary, OpenAiCompatibleAssistantAdapter>();
+        services.AddSingleton<IAdapterBoundary, OpenTelemetryAdapter>();
+
+        return services;
+    }
+}

--- a/src/Andreja.AppHost/Program.cs
+++ b/src/Andreja.AppHost/Program.cs
@@ -1,0 +1,32 @@
+using Andreja.AppHost.Components;
+using Andreja.AppHost.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+builder.Services.AddAndrejaFoundation(builder.Configuration);
+builder.Host.UseDefaultServiceProvider((context, options) =>
+{
+    options.ValidateScopes = context.HostingEnvironment.IsDevelopment();
+    options.ValidateOnBuild = true;
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
+app.UseHttpsRedirection();
+app.UseAntiforgery();
+app.MapStaticAssets();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();
+
+public partial class Program;

--- a/src/Andreja.AppHost/appsettings.Development.json
+++ b/src/Andreja.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Andreja.AppHost/appsettings.json
+++ b/src/Andreja.AppHost/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Andreja": {
+    "InstanceName": "local"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Andreja.AppHost/wwwroot/app.css
+++ b/src/Andreja.AppHost/wwwroot/app.css
@@ -1,0 +1,38 @@
+h1:focus {
+    outline: none;
+}
+
+.valid.modified:not([type=checkbox]) {
+    outline: 1px solid #26b050;
+}
+
+.invalid {
+    outline: 1px solid #e50000;
+}
+
+.validation-message {
+    color: #e50000;
+}
+
+.blazor-error-boundary {
+    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45NjMgOTkgMjM2IDk3LjA2NTEgMjM2IDk0LjY3ODIgMjM2IDk0LjM3OTkgMjM2LjAzMSA5NC4wODg2IDIzNi4wODkgOTMuODA3MkwyMzYuMzM4IDkzLjAxNjIgMjM2Ljg1OCA5Mi4xMzE0IDI1OS40NzMgNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3Ljg3OSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N0MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvZz48L3N2Zz4=) no-repeat 1rem/1.8rem, #b32121;
+    padding: 1rem 1rem 1rem 3.7rem;
+    color: white;
+}
+
+    .blazor-error-boundary::after {
+        content: "An error has occurred."
+    }
+
+.darker-border-checkbox.form-check-input {
+    border-color: #929292;
+}
+
+.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
+    color: var(--bs-secondary-color);
+    text-align: end;
+}
+
+.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
+    text-align: start;
+}

--- a/src/Andreja.Platform.Contracts/Andreja.Platform.Contracts.csproj
+++ b/src/Andreja.Platform.Contracts/Andreja.Platform.Contracts.csproj
@@ -1,0 +1,3 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/src/Andreja.Platform.Contracts/Composition/IAdapterBoundary.cs
+++ b/src/Andreja.Platform.Contracts/Composition/IAdapterBoundary.cs
@@ -1,0 +1,3 @@
+namespace Andreja.Platform.Contracts.Composition;
+
+public interface IAdapterBoundary;

--- a/src/Andreja.Platform.Contracts/Composition/IModuleBoundary.cs
+++ b/src/Andreja.Platform.Contracts/Composition/IModuleBoundary.cs
@@ -1,0 +1,3 @@
+namespace Andreja.Platform.Contracts.Composition;
+
+public interface IModuleBoundary;

--- a/src/Andreja.Platform.Contracts/PlatformContractAssembly.cs
+++ b/src/Andreja.Platform.Contracts/PlatformContractAssembly.cs
@@ -1,0 +1,8 @@
+using System.Reflection;
+
+namespace Andreja.Platform.Contracts;
+
+public static class PlatformContractAssembly
+{
+    public static Assembly Reference => typeof(PlatformContractAssembly).Assembly;
+}

--- a/src/Modules/Andreja.Modules/Andreja.Modules.csproj
+++ b/src/Modules/Andreja.Modules/Andreja.Modules.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Andreja.Platform.Contracts\Andreja.Platform.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Modules/Andreja.Modules/Assistant/AssistantModule.cs
+++ b/src/Modules/Andreja.Modules/Assistant/AssistantModule.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Modules.Assistant;
+
+public sealed class AssistantModule : IModuleBoundary;

--- a/src/Modules/Andreja.Modules/Channels/ChannelsModule.cs
+++ b/src/Modules/Andreja.Modules/Channels/ChannelsModule.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Modules.Channels;
+
+public sealed class ChannelsModule : IModuleBoundary;

--- a/src/Modules/Andreja.Modules/Identity/IdentityModule.cs
+++ b/src/Modules/Andreja.Modules/Identity/IdentityModule.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Modules.Identity;
+
+public sealed class IdentityModule : IModuleBoundary;

--- a/src/Modules/Andreja.Modules/OpenLoops/OpenLoopsModule.cs
+++ b/src/Modules/Andreja.Modules/OpenLoops/OpenLoopsModule.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Modules.OpenLoops;
+
+public sealed class OpenLoopsModule : IModuleBoundary;

--- a/src/Modules/Andreja.Modules/Portability/PortabilityModule.cs
+++ b/src/Modules/Andreja.Modules/Portability/PortabilityModule.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Modules.Portability;
+
+public sealed class PortabilityModule : IModuleBoundary;

--- a/src/Modules/Andreja.Modules/Skills/SkillsModule.cs
+++ b/src/Modules/Andreja.Modules/Skills/SkillsModule.cs
@@ -1,0 +1,5 @@
+using Andreja.Platform.Contracts.Composition;
+
+namespace Andreja.Modules.Skills;
+
+public sealed class SkillsModule : IModuleBoundary;

--- a/tests/Andreja.ArchitectureTests/Andreja.ArchitectureTests.csproj
+++ b/tests/Andreja.ArchitectureTests/Andreja.ArchitectureTests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Andreja.Api.Contracts\Andreja.Api.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Andreja.Platform.Contracts\Andreja.Platform.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Modules\Andreja.Modules\Andreja.Modules.csproj" />
+    <ProjectReference Include="..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
+++ b/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
@@ -1,0 +1,49 @@
+using Andreja.Api.Contracts;
+using Andreja.Modules.OpenLoops;
+using Andreja.Platform.Contracts;
+
+namespace Andreja.ArchitectureTests;
+
+public sealed class DependencyDirectionTests
+{
+    [Fact]
+    public void ModulesDoNotReferenceOutwardLayers()
+    {
+        string[] forbiddenAssemblyPrefixes =
+        [
+            "Andreja.Adapters",
+            "Andreja.Api.Contracts",
+            "Andreja.AppHost",
+            "Microsoft.AspNetCore",
+            "Microsoft.EntityFrameworkCore",
+        ];
+
+        var references = typeof(OpenLoopsModule).Assembly
+            .GetReferencedAssemblies()
+            .Select(reference => reference.Name ?? string.Empty)
+            .ToArray();
+
+        Assert.DoesNotContain(
+            references,
+            reference => forbiddenAssemblyPrefixes.Any(
+                prefix => reference.StartsWith(prefix, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ContractsDoNotReferenceModulesAdaptersOrHost()
+    {
+        var contractAssemblies = new[]
+        {
+            ApiContractAssembly.Reference,
+            PlatformContractAssembly.Reference,
+        };
+
+        var outwardReferences = contractAssemblies
+            .SelectMany(assembly => assembly.GetReferencedAssemblies())
+            .Select(reference => reference.Name ?? string.Empty)
+            .Where(reference => reference.StartsWith("Andreja.", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Empty(outwardReferences);
+    }
+}

--- a/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
+++ b/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
@@ -6,27 +6,38 @@ namespace Andreja.ArchitectureTests;
 
 public sealed class DependencyDirectionTests
 {
+    private static readonly HashSet<string> ApprovedModuleAssemblyReferences =
+        new(StringComparer.Ordinal)
+        {
+            "Andreja.Platform.Contracts",
+            // Framework-neutral facade emitted for fundamental BCL types.
+            "System.Runtime",
+        };
+
     [Fact]
     public void ModulesDoNotReferenceOutwardLayers()
     {
-        string[] forbiddenAssemblyPrefixes =
-        [
-            "Andreja.Adapters",
-            "Andreja.Api.Contracts",
-            "Andreja.AppHost",
-            "Microsoft.AspNetCore",
-            "Microsoft.EntityFrameworkCore",
-        ];
+        var unapprovedReferences = FindUnapprovedModuleReferences(
+            typeof(OpenLoopsModule).Assembly.GetReferencedAssemblies());
 
-        var references = typeof(OpenLoopsModule).Assembly
-            .GetReferencedAssemblies()
-            .Select(reference => reference.Name ?? string.Empty)
-            .ToArray();
+        Assert.Empty(unapprovedReferences);
+    }
 
-        Assert.DoesNotContain(
-            references,
-            reference => forbiddenAssemblyPrefixes.Any(
-                prefix => reference.StartsWith(prefix, StringComparison.Ordinal)));
+    [Theory]
+    [InlineData("Andreja.Adapters")]
+    [InlineData("Andreja.Api.Contracts")]
+    [InlineData("Andreja.AppHost")]
+    [InlineData("Microsoft.AspNetCore")]
+    [InlineData("Microsoft.EntityFrameworkCore")]
+    [InlineData("Npgsql")]
+    [InlineData("Azure.AI.OpenAI")]
+    [InlineData("Future.ProviderSdk")]
+    public void ModuleReferenceAllowlistRejectsNonApprovedAssemblies(string assemblyName)
+    {
+        var unapprovedReferences = FindUnapprovedModuleReferences(
+            [new(assemblyName)]);
+
+        Assert.Equal([assemblyName], unapprovedReferences);
     }
 
     [Fact]
@@ -45,5 +56,15 @@ public sealed class DependencyDirectionTests
             .ToArray();
 
         Assert.Empty(outwardReferences);
+    }
+
+    private static string[] FindUnapprovedModuleReferences(
+        IEnumerable<System.Reflection.AssemblyName> references)
+    {
+        return references
+            .Select(reference => reference.Name ?? string.Empty)
+            .Where(reference => !ApprovedModuleAssemblyReferences.Contains(reference))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
     }
 }

--- a/tests/Andreja.UnitTests/Andreja.UnitTests.csproj
+++ b/tests/Andreja.UnitTests/Andreja.UnitTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Andreja.AppHost\Andreja.AppHost.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Andreja.UnitTests/FoundationRegistrationTests.cs
+++ b/tests/Andreja.UnitTests/FoundationRegistrationTests.cs
@@ -1,0 +1,49 @@
+using Andreja.AppHost.Hosting;
+using Andreja.Platform.Contracts.Composition;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Andreja.UnitTests;
+
+public sealed class FoundationRegistrationTests
+{
+    [Fact]
+    public void FoundationRegistersEachDeclaredModuleAndAdapter()
+    {
+        var configuration = CreateConfiguration("test");
+        var services = new ServiceCollection();
+
+        services.AddAndrejaFoundation(configuration);
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Equal(6, provider.GetServices<IModuleBoundary>().Count());
+        Assert.Equal(4, provider.GetServices<IAdapterBoundary>().Count());
+    }
+
+    [Fact]
+    public void FoundationRejectsInvalidOptions()
+    {
+        var configuration = CreateConfiguration(string.Empty);
+        var services = new ServiceCollection();
+
+        services.AddAndrejaFoundation(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<AndrejaHostOptions>>().Value);
+    }
+
+    private static IConfiguration CreateConfiguration(string instanceName)
+    {
+        Dictionary<string, string?> values = new()
+        {
+            [$"{AndrejaHostOptions.SectionName}:InstanceName"] = instanceName,
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}


### PR DESCRIPTION
## Why

Closes #39

Establishes the compileable Phase 1A bottom foundation so dependent slices can add behavior without first choosing provider or cloud implementations.

## Approach

- Pin installed .NET SDK 10.0.301 and centralize nullable, analyzers, warnings-as-errors, deterministic builds, and test package versions.
- Add a minimal modular-monolith solution: API/platform contracts, one module assembly with six capability seams, one outer-adapter assembly with four provider-neutral seams, and an empty Blazor AppHost composition root.
- Register explicit module/adapter markers through DI and bind startup-validated host options.
- Enforce ADR 0001 with an exact module-reference allowlist: `System.Runtime` (the framework-neutral fundamental BCL facade) and `Andreja.Platform.Contracts`. Any additional BCL or external assembly requires an explicit, justified allowlist change.
- Add negative architecture-test cases proving that adapters, API contracts, AppHost, ASP.NET Core, EF Core, Npgsql, a model SDK, and an arbitrary future provider SDK are rejected.
- Working as the documented general-purpose fallback under T'Pol accountability; Spock/Data review remains appropriate for this draft.

## Charter impact

This is a reversible, behavior-free foundation. It creates no cloud resources, provider integrations, credentials, persistence, identity, assistant, task, container, or personal-data paths. The minimal two-assembly module/adapter layout avoids project-per-ring ceremony while preserving an enforceable inward dependency boundary.

## Validation

Executed from the repository root after the review fix:

- `dotnet restore Andreja.slnx` -> succeeded; all projects up to date.
- `dotnet build Andreja.slnx --no-restore` -> succeeded; 0 warnings, 0 errors.
- `dotnet test Andreja.slnx --no-build` -> succeeded; architecture 10/10 and unit 2/2, total 12 passed, 0 failed, 0 skipped.
- `dotnet format Andreja.slnx --verify-no-changes --no-restore` -> succeeded; exit code 0, no changes required.
- `git diff --check` -> succeeded.

## Gates

- [x] Architecture/contract impact recorded
- [x] Security/privacy/legal review recorded as no new runtime/data/provider behavior
- [x] Cost/operability impact recorded as local-only with no cloud resources
- [x] Company charter impact recorded
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated through `docs/development.md`
- [x] No personal data, prompts, credentials, or connector content included
- [ ] Hosted Actions evidence (externally blocked before runner startup by the repository/account billing or spending-limit condition)

## Stack

Bottom foundation PR targeting `main`; no parent layer.
