### PR TITLE
Implement Phase 1A assistant and proposal contracts

### DIFF
--- a/src/Adapters/Andreja.Adapters/Assistant.OpenAiCompatible/OpenAiCompatibleAssistantAdapter.cs
+++ b/src/Adapters/Andreja.Adapters/Assistant.OpenAiCompatible/OpenAiCompatibleAssistantAdapter.cs
@@ -1,5 +1,177 @@
+using Andreja.Platform.Contracts.Assistant;
 using Andreja.Platform.Contracts.Composition;
 
 namespace Andreja.Adapters.Assistant.OpenAiCompatible;
 
-public sealed class OpenAiCompatibleAssistantAdapter : IAdapterBoundary;
+public interface IOpenAiCompatibleTransport
+{
+    ValueTask<AssistantResponse> CompleteAsync(
+        AssistantProviderProfile profile,
+        AssistantSessionRequest session,
+        AssistantRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed class OpenAiCompatibleAssistantAdapter(
+    AssistantProviderProfile profile,
+    IOpenAiCompatibleTransport transport)
+    : IAdapterBoundary, IAssistantProvider
+{
+    private readonly AssistantProviderProfile profile = Validate(profile);
+
+    public OpenAiCompatibleAssistantAdapter()
+        : this(
+            new(
+                new Uri("http://localhost/v1"),
+                "not-configured",
+                "credential://assistant/not-configured",
+                TimeSpan.FromSeconds(30),
+                "No provider has been configured.",
+                0,
+                0),
+            new DisabledTransport())
+    {
+    }
+
+    public ValueTask<AssistantProviderCapabilities> GetCapabilitiesAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(new AssistantProviderCapabilities(
+            "openai-compatible",
+            profile.Model,
+            AssistantCapability.TextCompletion
+                | AssistantCapability.TypedTools
+                | AssistantCapability.UsageReporting
+                | AssistantCapability.Cancellation));
+    }
+
+    public ValueTask<IAssistantSession> CreateSessionAsync(
+        AssistantSessionRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        IAssistantSession session = new Session(profile, request, transport);
+        return ValueTask.FromResult(session);
+    }
+
+    public static AssistantProviderProfile Validate(AssistantProviderProfile candidate)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        if (!candidate.Endpoint.IsAbsoluteUri
+            || !string.IsNullOrEmpty(candidate.Endpoint.UserInfo)
+            || !string.IsNullOrEmpty(candidate.Endpoint.Fragment)
+            || (candidate.Endpoint.Scheme != Uri.UriSchemeHttps
+                && !(candidate.Endpoint.Scheme == Uri.UriSchemeHttp && candidate.Endpoint.IsLoopback)))
+        {
+            throw new ArgumentException(
+                "The endpoint must be absolute HTTPS, or HTTP only for a loopback host, with no user information or fragment.",
+                nameof(candidate));
+        }
+
+        if (string.IsNullOrWhiteSpace(candidate.Model))
+        {
+            throw new ArgumentException("A model is required.", nameof(candidate));
+        }
+
+        if (!Uri.TryCreate(candidate.CredentialHandle, UriKind.Absolute, out var handle)
+            || handle.Scheme != "credential"
+            || !string.IsNullOrEmpty(handle.UserInfo)
+            || !string.IsNullOrEmpty(handle.Query)
+            || !string.IsNullOrEmpty(handle.Fragment)
+            || string.IsNullOrWhiteSpace(handle.Host)
+            || handle.AbsolutePath == "/")
+        {
+            throw new ArgumentException(
+                "A non-secret credential:// handle is required.",
+                nameof(candidate));
+        }
+
+        if (candidate.Timeout <= TimeSpan.Zero
+            || string.IsNullOrWhiteSpace(candidate.RetentionDisclosure)
+            || candidate.MaximumInputUnits is < 0
+            || candidate.MaximumOutputUnits is < 0)
+        {
+            throw new ArgumentException("The provider policy is invalid.", nameof(candidate));
+        }
+
+        return candidate;
+    }
+
+    private sealed class Session(
+        AssistantProviderProfile profile,
+        AssistantSessionRequest request,
+        IOpenAiCompatibleTransport transport)
+        : IAssistantSession
+    {
+        private readonly CancellationTokenSource sessionCancellation = new();
+        private bool disposed;
+
+        public async ValueTask<AssistantResponse> CompleteAsync(
+            AssistantRequest assistantRequest,
+            CancellationToken cancellationToken)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            using var timeout = new CancellationTokenSource(profile.Timeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                sessionCancellation.Token,
+                timeout.Token);
+            return await transport.CompleteAsync(
+                profile,
+                request,
+                assistantRequest,
+                linked.Token).ConfigureAwait(false);
+        }
+
+        public ValueTask CancelAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            sessionCancellation.Cancel();
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+                sessionCancellation.Cancel();
+                sessionCancellation.Dispose();
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class DisabledTransport : IOpenAiCompatibleTransport
+    {
+        public ValueTask<AssistantResponse> CompleteAsync(
+            AssistantProviderProfile profile,
+            AssistantSessionRequest session,
+            AssistantRequest request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(new AssistantResponse(
+                request.RequestId,
+                AssistantResponseStatus.Failed,
+                null,
+                [],
+                new(
+                    "openai-compatible",
+                    profile.Model,
+                    null,
+                    null,
+                    TimeSpan.Zero,
+                    "not-configured",
+                    0,
+                    0),
+                new(
+                    "provider-not-configured",
+                    "The OpenAI-compatible provider is not configured.",
+                    false)));
+        }
+    }
+}

--- a/src/Andreja.Platform.Contracts/Assistant/AssistantContracts.cs
+++ b/src/Andreja.Platform.Contracts/Assistant/AssistantContracts.cs
@@ -1,0 +1,92 @@
+using Andreja.Platform.Contracts.Skills;
+
+namespace Andreja.Platform.Contracts.Assistant;
+
+[Flags]
+public enum AssistantCapability
+{
+    None = 0,
+    TextCompletion = 1,
+    TypedTools = 2,
+    UsageReporting = 4,
+    Cancellation = 8,
+}
+
+public enum AssistantResponseStatus
+{
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+public sealed record AssistantProviderCapabilities(
+    string Provider,
+    string Model,
+    AssistantCapability Capabilities);
+
+public sealed record AssistantExecutionContext(
+    Guid TenantId,
+    Guid PrincipalId,
+    string Purpose);
+
+public sealed record AssistantSessionRequest(
+    Guid SessionId,
+    AssistantExecutionContext Context,
+    IReadOnlyList<ToolDefinition> AllowedTools);
+
+public sealed record AssistantRequest(
+    Guid RequestId,
+    string Content,
+    IReadOnlyList<string> AllowedToolNames);
+
+public sealed record AssistantToolCall(
+    string ToolName,
+    IReadOnlyDictionary<string, System.Text.Json.JsonElement> Arguments);
+
+public sealed record AssistantUsage(
+    string Provider,
+    string Model,
+    long? InputUnits,
+    long? OutputUnits,
+    TimeSpan Duration,
+    string ResultClass,
+    int RetryCount,
+    int ToolCount);
+
+public sealed record AssistantFailure(string Code, string Message, bool IsTransient);
+
+public sealed record AssistantResponse(
+    Guid RequestId,
+    AssistantResponseStatus Status,
+    string? Content,
+    IReadOnlyList<AssistantToolCall> ToolCalls,
+    AssistantUsage Usage,
+    AssistantFailure? Failure);
+
+public interface IAssistantProvider
+{
+    ValueTask<AssistantProviderCapabilities> GetCapabilitiesAsync(
+        CancellationToken cancellationToken);
+
+    ValueTask<IAssistantSession> CreateSessionAsync(
+        AssistantSessionRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface IAssistantSession : IAsyncDisposable
+{
+    ValueTask<AssistantResponse> CompleteAsync(
+        AssistantRequest request,
+        CancellationToken cancellationToken);
+
+    ValueTask CancelAsync(CancellationToken cancellationToken);
+}
+
+public sealed record AssistantProviderProfile(
+    Uri Endpoint,
+    string Model,
+    string CredentialHandle,
+    TimeSpan Timeout,
+    string RetentionDisclosure,
+    long? MaximumInputUnits,
+    long? MaximumOutputUnits);

--- a/src/Andreja.Platform.Contracts/Peers/PeerContracts.cs
+++ b/src/Andreja.Platform.Contracts/Peers/PeerContracts.cs
@@ -1,0 +1,56 @@
+namespace Andreja.Platform.Contracts.Peers;
+
+public sealed record SignedPeerEnvelope(
+    string ProtocolVersion,
+    Guid EnvelopeId,
+    Guid SenderId,
+    Guid RecipientId,
+    Guid GrantId,
+    string Purpose,
+    string Nonce,
+    string IdempotencyKey,
+    DateTimeOffset IssuedAt,
+    DateTimeOffset ExpiresAt,
+    string PayloadType,
+    string PayloadDigest,
+    string SigningAlgorithm,
+    string KeyId,
+    string Signature);
+
+public sealed record PeerReceiveContext(
+    Guid ExpectedSenderId,
+    Guid ExpectedRecipientId,
+    Guid ExpectedGrantId,
+    string ExpectedPurpose,
+    DateTimeOffset ReceivedAt);
+
+public enum PeerReceiveOutcome
+{
+    Accepted,
+    IdempotentReplay,
+    Malformed,
+    InvalidVersion,
+    InvalidSignature,
+    WrongAudience,
+    WrongPurpose,
+    WrongGrant,
+    Expired,
+    NotYetValid,
+    Replay,
+    IdempotencyConflict,
+    UnknownAlgorithm,
+    UnknownKey,
+}
+
+public sealed record PeerReceiveResult(
+    PeerReceiveOutcome Outcome,
+    bool EffectApplied,
+    string? ReceiptId);
+
+public interface IPeerChannel
+{
+    ValueTask<PeerReceiveResult> ReceiveAsync(
+        SignedPeerEnvelope envelope,
+        PeerReceiveContext context,
+        CancellationToken cancellationToken);
+}

--- a/src/Andreja.Platform.Contracts/Proposals/ProposalContracts.cs
+++ b/src/Andreja.Platform.Contracts/Proposals/ProposalContracts.cs
@@ -1,0 +1,100 @@
+namespace Andreja.Platform.Contracts.Proposals;
+
+public enum ProposalState
+{
+    Pending,
+    Confirmed,
+    Rejected,
+    Cancelled,
+    Expired,
+}
+
+public enum ProposalAction
+{
+    Confirm,
+    Reject,
+    Cancel,
+}
+
+public sealed record ProposalOperation(
+    string Operation,
+    string ResourceReference,
+    string CanonicalPayload,
+    string PayloadDigest);
+
+public sealed record ProposalDiff(
+    string BeforeCanonical,
+    string AfterCanonical);
+
+public sealed record ProposalSource(
+    string Kind,
+    string Reference,
+    Guid ActorId);
+
+public sealed record Proposal(
+    Guid ProposalId,
+    long Version,
+    Guid TenantId,
+    Guid ActorId,
+    string Purpose,
+    ProposalSource Source,
+    ProposalOperation Operation,
+    ProposalDiff Diff,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset ExpiresAt,
+    ProposalState State);
+
+public sealed record ProposalTransitionRequest(
+    Guid ProposalId,
+    long ExpectedVersion,
+    Guid TenantId,
+    Guid ActorId,
+    ProposalAction Action,
+    string IdempotencyKey,
+    DateTimeOffset OccurredAt);
+
+public enum ProposalTransitionOutcome
+{
+    Applied,
+    IdempotentReplay,
+    NotFound,
+    Conflict,
+    Expired,
+    Denied,
+    InvalidState,
+}
+
+public sealed record ProposalTransitionResult(
+    ProposalTransitionOutcome Outcome,
+    Proposal? Proposal);
+
+public sealed record ProposalAuditEntry(
+    Guid AuditId,
+    Guid ProposalId,
+    long ProposalVersion,
+    Guid TenantId,
+    Guid ActorId,
+    ProposalAction Action,
+    ProposalTransitionOutcome Outcome,
+    string SourceKind,
+    string SourceReference,
+    DateTimeOffset OccurredAt);
+
+public interface IProposalStore
+{
+    ValueTask<bool> TryCreateAsync(Proposal proposal, CancellationToken cancellationToken);
+
+    ValueTask<Proposal?> GetAsync(
+        Guid tenantId,
+        Guid proposalId,
+        CancellationToken cancellationToken);
+
+    ValueTask<ProposalTransitionResult> TryTransitionAsync(
+        ProposalTransitionRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface IProposalAuditSink
+{
+    ValueTask AppendAsync(ProposalAuditEntry entry, CancellationToken cancellationToken);
+}

--- a/src/Andreja.Platform.Contracts/Sharing/SharingContracts.cs
+++ b/src/Andreja.Platform.Contracts/Sharing/SharingContracts.cs
@@ -1,0 +1,110 @@
+namespace Andreja.Platform.Contracts.Sharing;
+
+public enum DisclosureLevel
+{
+    Existence = 0,
+    Timing = 1,
+    Summary = 2,
+    Full = 3,
+}
+
+public enum ConsentState
+{
+    Offered,
+    Accepted,
+    Active,
+    Rejected,
+    Expired,
+    Revoked,
+}
+
+public sealed record ConsentTerms(
+    string Purpose,
+    DisclosureLevel MaximumDisclosure,
+    IReadOnlySet<string> AllowedOperations,
+    DateTimeOffset ValidFrom,
+    DateTimeOffset ExpiresAt);
+
+public sealed record ConsentDecision(
+    ConsentState State,
+    Guid ActorId,
+    DateTimeOffset OccurredAt);
+
+public sealed record ConsentRecord(
+    Guid ConsentId,
+    string Version,
+    Guid GrantId,
+    Guid OfferingPrincipalId,
+    Guid ReceivingPrincipalId,
+    ConsentTerms Terms,
+    IReadOnlyList<ConsentDecision> Timeline);
+
+public sealed record Grant(
+    Guid GrantId,
+    string Version,
+    Guid OwnerTenantId,
+    string ResourceReference,
+    string ScopeReference,
+    Guid GranteePrincipalId,
+    string Purpose,
+    DisclosureLevel MaximumDisclosure,
+    IReadOnlySet<string> AllowedOperations,
+    DateTimeOffset ValidFrom,
+    DateTimeOffset ExpiresAt,
+    bool IsRevoked,
+    DateTimeOffset? RevokedAt,
+    Guid ConsentId);
+
+public enum ShareAuditOutcome
+{
+    Allowed,
+    Denied,
+}
+
+public sealed record ShareAuditEntry(
+    Guid AuditId,
+    string Version,
+    Guid TenantId,
+    Guid ActorId,
+    Guid PeerId,
+    Guid GrantId,
+    Guid ConsentId,
+    string ResourceReference,
+    string ScopeReference,
+    string Purpose,
+    DisclosureLevel DisclosureLevel,
+    string Operation,
+    ShareAuditOutcome Outcome,
+    string? EnvelopeDigest,
+    string? PayloadDigest,
+    DateTimeOffset OccurredAt);
+
+public interface IShareAuditSink
+{
+    ValueTask AppendAsync(ShareAuditEntry entry, CancellationToken cancellationToken);
+}
+
+public static class DisclosurePolicy
+{
+    public static DisclosureLevel Reduce(
+        DisclosureLevel requested,
+        DisclosureLevel granted,
+        DisclosureLevel sensitivityMaximum)
+    {
+        Validate(requested);
+        Validate(granted);
+        Validate(sensitivityMaximum);
+
+        return (DisclosureLevel)Math.Min(
+            (int)requested,
+            Math.Min((int)granted, (int)sensitivityMaximum));
+    }
+
+    private static void Validate(DisclosureLevel level)
+    {
+        if (!Enum.IsDefined(level))
+        {
+            throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown disclosure level.");
+        }
+    }
+}

--- a/src/Andreja.Platform.Contracts/Skills/SkillContracts.cs
+++ b/src/Andreja.Platform.Contracts/Skills/SkillContracts.cs
@@ -1,0 +1,83 @@
+using Andreja.Platform.Contracts.Proposals;
+using System.Text.Json;
+
+namespace Andreja.Platform.Contracts.Skills;
+
+public enum ToolValueKind
+{
+    Text,
+    Numeric,
+    Logical,
+    Structured,
+    Sequence,
+}
+
+public sealed record ToolFieldSchema(
+    string Name,
+    ToolValueKind Kind,
+    bool Required);
+
+public sealed record ToolDefinition(
+    string Name,
+    string Version,
+    string Description,
+    IReadOnlyList<ToolFieldSchema> InputSchema,
+    IReadOnlyList<string> RequiredCapabilities,
+    IReadOnlyList<string> AllowedPurposes);
+
+public sealed record SkillManifest(
+    string SkillId,
+    string Version,
+    string DisplayName,
+    IReadOnlyList<ToolDefinition> Tools);
+
+public sealed record SkillExecutionContext(
+    Guid TenantId,
+    Guid PrincipalId,
+    string Purpose,
+    IReadOnlySet<string> GrantedCapabilities);
+
+public sealed record SkillInvocation(
+    string SkillId,
+    string SkillVersion,
+    string ToolName,
+    Guid TenantId,
+    string Purpose,
+    IReadOnlyDictionary<string, JsonElement> Arguments,
+    string ManifestDigest);
+
+public enum SkillResultStatus
+{
+    Completed,
+    Proposed,
+    Denied,
+    Invalid,
+    Failed,
+    Cancelled,
+}
+
+public sealed record SkillFailure(string Code, string Message);
+
+public sealed record SkillResult(
+    SkillResultStatus Status,
+    JsonElement? Output,
+    Proposal? Proposal,
+    SkillFailure? Failure);
+
+public delegate ValueTask<SkillResult> SkillToolHandler(
+    SkillInvocation invocation,
+    SkillExecutionContext context,
+    CancellationToken cancellationToken);
+
+public interface ISkillHost
+{
+    ValueTask<SkillManifest?> ResolveManifestAsync(
+        string skillId,
+        string version,
+        CancellationToken cancellationToken);
+
+    ValueTask<SkillResult> InvokeAsync(
+        SkillInvocation invocation,
+        SkillExecutionContext context,
+        CancellationToken cancellationToken);
+}

--- a/src/Modules/Andreja.Modules/Assistant/DeterministicAssistantProvider.cs
+++ b/src/Modules/Andreja.Modules/Assistant/DeterministicAssistantProvider.cs
@@ -1,0 +1,86 @@
+using Andreja.Platform.Contracts.Assistant;
+
+namespace Andreja.Modules.Assistant;
+
+public sealed class DeterministicAssistantProvider : IAssistantProvider
+{
+    private readonly AssistantProviderCapabilities capabilities;
+    private readonly Func<AssistantRequest, CancellationToken, ValueTask<AssistantResponse>> responder;
+
+    public DeterministicAssistantProvider(
+        AssistantProviderCapabilities capabilities,
+        Func<AssistantRequest, CancellationToken, ValueTask<AssistantResponse>> responder)
+    {
+        this.capabilities = capabilities;
+        this.responder = responder;
+    }
+
+    public ValueTask<AssistantProviderCapabilities> GetCapabilitiesAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(capabilities);
+    }
+
+    public ValueTask<IAssistantSession> CreateSessionAsync(
+        AssistantSessionRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (request.SessionId == Guid.Empty)
+        {
+            throw new ArgumentException("A session ID is required.", nameof(request));
+        }
+
+        IAssistantSession session = new Session(request, responder);
+        return ValueTask.FromResult(session);
+    }
+
+    private sealed class Session(
+        AssistantSessionRequest sessionRequest,
+        Func<AssistantRequest, CancellationToken, ValueTask<AssistantResponse>> responder)
+        : IAssistantSession
+    {
+        private readonly CancellationTokenSource sessionCancellation = new();
+        private bool disposed;
+
+        public async ValueTask<AssistantResponse> CompleteAsync(
+            AssistantRequest request,
+            CancellationToken cancellationToken)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            if (request.AllowedToolNames.Any(
+                requested => !sessionRequest.AllowedTools.Any(
+                    allowed => string.Equals(allowed.Name, requested, StringComparison.Ordinal))))
+            {
+                throw new InvalidOperationException("The request widened the session tool allowlist.");
+            }
+
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                sessionCancellation.Token);
+            return await responder(request, linked.Token).ConfigureAwait(false);
+        }
+
+        public ValueTask CancelAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            sessionCancellation.Cancel();
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+                sessionCancellation.Cancel();
+                sessionCancellation.Dispose();
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Modules/Andreja.Modules/Channels/LocalPeerChannel.cs
+++ b/src/Modules/Andreja.Modules/Channels/LocalPeerChannel.cs
@@ -1,0 +1,211 @@
+using Andreja.Platform.Contracts.Peers;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Andreja.Modules.Channels;
+
+public sealed class LocalPeerChannel : IPeerChannel
+{
+    public const string ProtocolVersion = "andreja.peer/1";
+    public const string FixtureAlgorithm = "HMAC-SHA256-FIXTURE";
+
+    private readonly object gate = new();
+    private readonly Dictionary<string, byte[]> verificationKeys;
+    private readonly TimeSpan maximumClockSkew;
+    private readonly HashSet<(Guid Sender, string Nonce)> nonces = [];
+    private readonly Dictionary<(Guid Sender, string Key), IdempotencyReceipt> receipts = [];
+
+    public LocalPeerChannel(
+        IReadOnlyDictionary<string, byte[]> verificationKeys,
+        TimeSpan? maximumClockSkew = null)
+    {
+        ArgumentNullException.ThrowIfNull(verificationKeys);
+        this.verificationKeys = verificationKeys.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.ToArray(),
+            StringComparer.Ordinal);
+        this.maximumClockSkew = maximumClockSkew ?? TimeSpan.FromMinutes(5);
+    }
+
+    public ValueTask<PeerReceiveResult> ReceiveAsync(
+        SignedPeerEnvelope envelope,
+        PeerReceiveContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var outcome = Validate(envelope, context);
+        if (outcome is not null)
+        {
+            return ValueTask.FromResult(new PeerReceiveResult(outcome.Value, false, null));
+        }
+
+        var sender = envelope.SenderId;
+        lock (gate)
+        {
+            if (!nonces.Add((sender, envelope.Nonce)))
+            {
+                return ValueTask.FromResult(
+                    new PeerReceiveResult(PeerReceiveOutcome.Replay, false, null));
+            }
+
+            var idempotencyKey = (sender, envelope.IdempotencyKey);
+            var fingerprint = IdempotencyFingerprint(envelope);
+            if (receipts.TryGetValue(idempotencyKey, out var receipt))
+            {
+                return ValueTask.FromResult(
+                    receipt.Fingerprint == fingerprint
+                        ? new PeerReceiveResult(
+                            PeerReceiveOutcome.IdempotentReplay,
+                            false,
+                            receipt.ReceiptId)
+                        : new PeerReceiveResult(
+                            PeerReceiveOutcome.IdempotencyConflict,
+                            false,
+                            null));
+            }
+
+            var receiptId = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(fingerprint)));
+            receipts.Add(idempotencyKey, new(fingerprint, receiptId));
+            return ValueTask.FromResult(
+                new PeerReceiveResult(PeerReceiveOutcome.Accepted, true, receiptId));
+        }
+    }
+
+    public static SignedPeerEnvelope SignFixture(
+        SignedPeerEnvelope unsignedEnvelope,
+        ReadOnlySpan<byte> key)
+    {
+        var canonical = Canonicalize(unsignedEnvelope with { Signature = string.Empty });
+        var signature = HMACSHA256.HashData(key, canonical);
+        return unsignedEnvelope with { Signature = Convert.ToBase64String(signature) };
+    }
+
+    public static byte[] Canonicalize(SignedPeerEnvelope envelope)
+    {
+        using var stream = new MemoryStream();
+        Append(stream, envelope.ProtocolVersion);
+        Append(stream, envelope.EnvelopeId.ToString("N"));
+        Append(stream, envelope.SenderId.ToString("N"));
+        Append(stream, envelope.RecipientId.ToString("N"));
+        Append(stream, envelope.GrantId.ToString("N"));
+        Append(stream, envelope.Purpose);
+        Append(stream, envelope.Nonce);
+        Append(stream, envelope.IdempotencyKey);
+        Append(stream, envelope.IssuedAt.ToUniversalTime().ToString("O"));
+        Append(stream, envelope.ExpiresAt.ToUniversalTime().ToString("O"));
+        Append(stream, envelope.PayloadType);
+        Append(stream, envelope.PayloadDigest);
+        Append(stream, envelope.SigningAlgorithm);
+        Append(stream, envelope.KeyId);
+        return stream.ToArray();
+    }
+
+    private PeerReceiveOutcome? Validate(
+        SignedPeerEnvelope envelope,
+        PeerReceiveContext context)
+    {
+        if (!string.Equals(envelope.ProtocolVersion, ProtocolVersion, StringComparison.Ordinal))
+        {
+            return PeerReceiveOutcome.InvalidVersion;
+        }
+
+        if (envelope.EnvelopeId == Guid.Empty
+            || envelope.SenderId == Guid.Empty
+            || envelope.RecipientId == Guid.Empty
+            || envelope.GrantId == Guid.Empty
+            || string.IsNullOrWhiteSpace(envelope.Purpose)
+            || string.IsNullOrWhiteSpace(envelope.Nonce)
+            || string.IsNullOrWhiteSpace(envelope.IdempotencyKey)
+            || string.IsNullOrWhiteSpace(envelope.PayloadType)
+            || string.IsNullOrWhiteSpace(envelope.PayloadDigest)
+            || envelope.ExpiresAt <= envelope.IssuedAt)
+        {
+            return PeerReceiveOutcome.Malformed;
+        }
+
+        if (!string.Equals(envelope.SigningAlgorithm, FixtureAlgorithm, StringComparison.Ordinal))
+        {
+            return PeerReceiveOutcome.UnknownAlgorithm;
+        }
+
+        if (!verificationKeys.TryGetValue(envelope.KeyId, out var key))
+        {
+            return PeerReceiveOutcome.UnknownKey;
+        }
+
+        if (!TryDecodeSignature(envelope.Signature, out var signature)
+            || !CryptographicOperations.FixedTimeEquals(
+                HMACSHA256.HashData(key, Canonicalize(envelope with { Signature = string.Empty })),
+                signature))
+        {
+            return PeerReceiveOutcome.InvalidSignature;
+        }
+
+        if (envelope.SenderId != context.ExpectedSenderId
+            || envelope.RecipientId != context.ExpectedRecipientId)
+        {
+            return PeerReceiveOutcome.WrongAudience;
+        }
+
+        if (!string.Equals(envelope.Purpose, context.ExpectedPurpose, StringComparison.Ordinal))
+        {
+            return PeerReceiveOutcome.WrongPurpose;
+        }
+
+        if (envelope.GrantId != context.ExpectedGrantId)
+        {
+            return PeerReceiveOutcome.WrongGrant;
+        }
+
+        if (context.ReceivedAt >= envelope.ExpiresAt)
+        {
+            return PeerReceiveOutcome.Expired;
+        }
+
+        if (envelope.IssuedAt > context.ReceivedAt + maximumClockSkew)
+        {
+            return PeerReceiveOutcome.NotYetValid;
+        }
+
+        return null;
+    }
+
+    private static bool TryDecodeSignature(string value, out byte[] signature)
+    {
+        try
+        {
+            signature = Convert.FromBase64String(value);
+            return true;
+        }
+        catch (FormatException)
+        {
+            signature = [];
+            return false;
+        }
+    }
+
+    private static string IdempotencyFingerprint(SignedPeerEnvelope envelope) =>
+        string.Join(
+            '\u001f',
+            envelope.SenderId,
+            envelope.RecipientId,
+            envelope.GrantId,
+            envelope.Purpose,
+            envelope.IdempotencyKey,
+            envelope.PayloadType,
+            envelope.PayloadDigest);
+
+    private static void Append(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Span<byte> length = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(length, bytes.Length);
+        stream.Write(length);
+        stream.Write(bytes);
+    }
+
+    private sealed record IdempotencyReceipt(string Fingerprint, string ReceiptId);
+}

--- a/src/Modules/Andreja.Modules/Proposals/InMemoryProposalStore.cs
+++ b/src/Modules/Andreja.Modules/Proposals/InMemoryProposalStore.cs
@@ -68,9 +68,18 @@ public sealed class InMemoryProposalStore : IProposalStore, IProposalAuditSink
             if (receipts.TryGetValue(receiptKey, out var receipt))
             {
                 var exactRetry = IsSameIntent(receipt.Request, request);
-                return ValueTask.FromResult(exactRetry
-                    ? receipt.Result with { Outcome = ProposalTransitionOutcome.IdempotentReplay }
-                    : new ProposalTransitionResult(ProposalTransitionOutcome.Conflict, receipt.Result.Proposal));
+                if (!exactRetry)
+                {
+                    return ValueTask.FromResult(
+                        new ProposalTransitionResult(
+                            ProposalTransitionOutcome.Conflict,
+                            receipt.Result.Proposal));
+                }
+
+                return ValueTask.FromResult(
+                    receipt.Result.Outcome == ProposalTransitionOutcome.Applied
+                        ? receipt.Result with { Outcome = ProposalTransitionOutcome.IdempotentReplay }
+                        : receipt.Result);
             }
 
             if (!proposals.TryGetValue(request.ProposalId, out var proposal))

--- a/src/Modules/Andreja.Modules/Proposals/InMemoryProposalStore.cs
+++ b/src/Modules/Andreja.Modules/Proposals/InMemoryProposalStore.cs
@@ -1,0 +1,216 @@
+using Andreja.Platform.Contracts.Proposals;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Andreja.Modules.Proposals;
+
+public sealed class InMemoryProposalStore : IProposalStore, IProposalAuditSink
+{
+    private readonly object gate = new();
+    private readonly Dictionary<Guid, Proposal> proposals = [];
+    private readonly Dictionary<(Guid ProposalId, string Key), TransitionReceipt> receipts = [];
+    private readonly HashSet<Guid> auditEntryIds = [];
+    private readonly List<ProposalAuditEntry> auditEntries = [];
+
+    public IReadOnlyList<ProposalAuditEntry> AuditEntries
+    {
+        get
+        {
+            lock (gate)
+            {
+                return auditEntries.ToArray();
+            }
+        }
+    }
+
+    public ValueTask<bool> TryCreateAsync(
+        Proposal proposal,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ValidateProposal(proposal);
+
+        lock (gate)
+        {
+            return ValueTask.FromResult(proposals.TryAdd(proposal.ProposalId, proposal));
+        }
+    }
+
+    public ValueTask<Proposal?> GetAsync(
+        Guid tenantId,
+        Guid proposalId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (gate)
+        {
+            proposals.TryGetValue(proposalId, out var proposal);
+            return ValueTask.FromResult(proposal?.TenantId == tenantId ? proposal : null);
+        }
+    }
+
+    public ValueTask<ProposalTransitionResult> TryTransitionAsync(
+        ProposalTransitionRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (gate)
+        {
+            if (string.IsNullOrWhiteSpace(request.IdempotencyKey))
+            {
+                return ValueTask.FromResult(new ProposalTransitionResult(
+                    ProposalTransitionOutcome.Conflict,
+                    null));
+            }
+
+            var receiptKey = (request.ProposalId, request.IdempotencyKey);
+            if (receipts.TryGetValue(receiptKey, out var receipt))
+            {
+                var exactRetry = IsSameIntent(receipt.Request, request);
+                return ValueTask.FromResult(exactRetry
+                    ? receipt.Result with { Outcome = ProposalTransitionOutcome.IdempotentReplay }
+                    : new ProposalTransitionResult(ProposalTransitionOutcome.Conflict, receipt.Result.Proposal));
+            }
+
+            if (!proposals.TryGetValue(request.ProposalId, out var proposal))
+            {
+                return ValueTask.FromResult(StoreReceipt(
+                    request,
+                    new ProposalTransitionResult(ProposalTransitionOutcome.NotFound, null)));
+            }
+
+            if (proposal.TenantId != request.TenantId || proposal.ActorId != request.ActorId)
+            {
+                return ValueTask.FromResult(StoreAndAudit(
+                    request,
+                    proposal,
+                    ProposalTransitionOutcome.Denied));
+            }
+
+            if (request.OccurredAt >= proposal.ExpiresAt)
+            {
+                var expired = proposal.State == ProposalState.Pending
+                    ? proposal with { State = ProposalState.Expired, Version = proposal.Version + 1 }
+                    : proposal;
+                proposals[proposal.ProposalId] = expired;
+                return ValueTask.FromResult(StoreAndAudit(
+                    request,
+                    expired,
+                    ProposalTransitionOutcome.Expired));
+            }
+
+            if (proposal.Version != request.ExpectedVersion)
+            {
+                return ValueTask.FromResult(StoreAndAudit(
+                    request,
+                    proposal,
+                    ProposalTransitionOutcome.Conflict));
+            }
+
+            if (proposal.State != ProposalState.Pending)
+            {
+                return ValueTask.FromResult(StoreAndAudit(
+                    request,
+                    proposal,
+                    ProposalTransitionOutcome.InvalidState));
+            }
+
+            var targetState = request.Action switch
+            {
+                ProposalAction.Confirm => ProposalState.Confirmed,
+                ProposalAction.Reject => ProposalState.Rejected,
+                ProposalAction.Cancel => ProposalState.Cancelled,
+                _ => throw new ArgumentOutOfRangeException(nameof(request), request.Action, "Unknown action."),
+            };
+            var transitioned = proposal with { State = targetState, Version = proposal.Version + 1 };
+            proposals[proposal.ProposalId] = transitioned;
+            return ValueTask.FromResult(StoreAndAudit(
+                request,
+                transitioned,
+                ProposalTransitionOutcome.Applied));
+        }
+    }
+
+    public ValueTask AppendAsync(
+        ProposalAuditEntry entry,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (gate)
+        {
+            if (!auditEntryIds.Add(entry.AuditId))
+            {
+                throw new InvalidOperationException("Proposal audit entries are append-only and unique.");
+            }
+
+            auditEntries.Add(entry);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private ProposalTransitionResult StoreAndAudit(
+        ProposalTransitionRequest request,
+        Proposal proposal,
+        ProposalTransitionOutcome outcome)
+    {
+        var result = StoreReceipt(request, new ProposalTransitionResult(outcome, proposal));
+        var entry = new ProposalAuditEntry(
+            Guid.CreateVersion7(),
+            proposal.ProposalId,
+            proposal.Version,
+            proposal.TenantId,
+            request.ActorId,
+            request.Action,
+            outcome,
+            proposal.Source.Kind,
+            proposal.Source.Reference,
+            request.OccurredAt);
+        auditEntryIds.Add(entry.AuditId);
+        auditEntries.Add(entry);
+        return result;
+    }
+
+    private ProposalTransitionResult StoreReceipt(
+        ProposalTransitionRequest request,
+        ProposalTransitionResult result)
+    {
+        receipts[(request.ProposalId, request.IdempotencyKey)] = new(request, result);
+        return result;
+    }
+
+    private static void ValidateProposal(Proposal proposal)
+    {
+        if (proposal.ProposalId == Guid.Empty
+            || proposal.Version < 1
+            || proposal.State != ProposalState.Pending
+            || proposal.ExpiresAt <= proposal.CreatedAt
+            || !string.Equals(
+                proposal.Operation.CanonicalPayload,
+                proposal.Diff.AfterCanonical,
+                StringComparison.Ordinal)
+            || !string.Equals(
+                proposal.Operation.PayloadDigest,
+                Convert.ToHexString(SHA256.HashData(
+                    Encoding.UTF8.GetBytes(proposal.Operation.CanonicalPayload))),
+                StringComparison.Ordinal))
+        {
+            throw new ArgumentException("The proposal is invalid.", nameof(proposal));
+        }
+    }
+
+    private static bool IsSameIntent(
+        ProposalTransitionRequest first,
+        ProposalTransitionRequest second) =>
+        first.ProposalId == second.ProposalId
+        && first.ExpectedVersion == second.ExpectedVersion
+        && first.TenantId == second.TenantId
+        && first.ActorId == second.ActorId
+        && first.Action == second.Action
+        && string.Equals(first.IdempotencyKey, second.IdempotencyKey, StringComparison.Ordinal);
+
+    private sealed record TransitionReceipt(
+        ProposalTransitionRequest Request,
+        ProposalTransitionResult Result);
+}

--- a/src/Modules/Andreja.Modules/Sharing/ConsentPolicy.cs
+++ b/src/Modules/Andreja.Modules/Sharing/ConsentPolicy.cs
@@ -1,0 +1,97 @@
+using Andreja.Platform.Contracts.Sharing;
+
+namespace Andreja.Modules.Sharing;
+
+public static class ConsentPolicy
+{
+    public static ConsentRecord Transition(
+        ConsentRecord record,
+        ConsentState target,
+        Guid actorId,
+        DateTimeOffset occurredAt)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (record.Timeline.Count == 0 || record.Timeline[0].State != ConsentState.Offered)
+        {
+            throw new InvalidOperationException("Consent must begin with an offer.");
+        }
+
+        var current = record.Timeline[^1];
+        if (occurredAt <= current.OccurredAt)
+        {
+            throw new InvalidOperationException("Consent decisions must be strictly ordered.");
+        }
+
+        var actorIsParty = actorId == record.OfferingPrincipalId
+            || actorId == record.ReceivingPrincipalId;
+        if (!actorIsParty)
+        {
+            throw new UnauthorizedAccessException("Only a consent party may change consent.");
+        }
+
+        if (target == ConsentState.Expired)
+        {
+            if (occurredAt < record.Terms.ExpiresAt)
+            {
+                throw new InvalidOperationException("Consent has not expired.");
+            }
+        }
+        else if (occurredAt >= record.Terms.ExpiresAt)
+        {
+            throw new InvalidOperationException("Expired consent cannot transition.");
+        }
+
+        var allowed = (current.State, target) switch
+        {
+            (ConsentState.Offered, ConsentState.Accepted) =>
+                actorId == record.ReceivingPrincipalId,
+            (ConsentState.Offered, ConsentState.Rejected) =>
+                actorId == record.ReceivingPrincipalId,
+            (ConsentState.Offered, ConsentState.Expired) => true,
+            (ConsentState.Accepted, ConsentState.Active) =>
+                actorId == record.OfferingPrincipalId,
+            (ConsentState.Accepted, ConsentState.Rejected) =>
+                actorId == record.ReceivingPrincipalId,
+            (ConsentState.Accepted, ConsentState.Expired) => true,
+            (ConsentState.Active, ConsentState.Revoked) => true,
+            (ConsentState.Active, ConsentState.Expired) => true,
+            _ => false,
+        };
+
+        if (!allowed)
+        {
+            throw new InvalidOperationException(
+                $"Consent cannot transition from {current.State} to {target}.");
+        }
+
+        return record with
+        {
+            Timeline = [.. record.Timeline, new ConsentDecision(target, actorId, occurredAt)],
+        };
+    }
+
+    public static bool IsGrantActive(
+        Grant grant,
+        ConsentRecord consent,
+        Guid grantee,
+        string purpose,
+        string operation,
+        DateTimeOffset now)
+    {
+        return grant.ConsentId == consent.ConsentId
+            && consent.GrantId == grant.GrantId
+            && consent.Timeline.Count > 0
+            && consent.Timeline[^1].State == ConsentState.Active
+            && grant.GranteePrincipalId == grantee
+            && string.Equals(grant.Purpose, purpose, StringComparison.Ordinal)
+            && string.Equals(consent.Terms.Purpose, purpose, StringComparison.Ordinal)
+            && grant.AllowedOperations.Contains(operation)
+            && consent.Terms.AllowedOperations.Contains(operation)
+            && !grant.IsRevoked
+            && now >= grant.ValidFrom
+            && now < grant.ExpiresAt
+            && now >= consent.Terms.ValidFrom
+            && now < consent.Terms.ExpiresAt;
+    }
+}

--- a/src/Modules/Andreja.Modules/Sharing/InMemoryShareAuditSink.cs
+++ b/src/Modules/Andreja.Modules/Sharing/InMemoryShareAuditSink.cs
@@ -1,0 +1,39 @@
+using Andreja.Platform.Contracts.Sharing;
+
+namespace Andreja.Modules.Sharing;
+
+public sealed class InMemoryShareAuditSink : IShareAuditSink
+{
+    private readonly object gate = new();
+    private readonly HashSet<Guid> entryIds = [];
+    private readonly List<ShareAuditEntry> entries = [];
+
+    public IReadOnlyList<ShareAuditEntry> Entries
+    {
+        get
+        {
+            lock (gate)
+            {
+                return entries.ToArray();
+            }
+        }
+    }
+
+    public ValueTask AppendAsync(
+        ShareAuditEntry entry,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (gate)
+        {
+            if (!entryIds.Add(entry.AuditId))
+            {
+                throw new InvalidOperationException("Share audit entries are append-only and unique.");
+            }
+
+            entries.Add(entry);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Modules/Andreja.Modules/Skills/InMemorySkillHost.cs
+++ b/src/Modules/Andreja.Modules/Skills/InMemorySkillHost.cs
@@ -1,0 +1,188 @@
+using Andreja.Platform.Contracts.Skills;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Andreja.Modules.Skills;
+
+public sealed class InMemorySkillHost : ISkillHost
+{
+    private readonly Dictionary<(string Id, string Version), Registration> registrations = [];
+
+    public void Register(SkillManifest manifest, IReadOnlyDictionary<string, SkillToolHandler> handlers)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        var declaredTools = manifest.Tools.Select(tool => tool.Name).ToHashSet(StringComparer.Ordinal);
+        if (declaredTools.Count != manifest.Tools.Count || !declaredTools.SetEquals(handlers.Keys))
+        {
+            throw new ArgumentException("Handlers must exactly match declared tools.", nameof(handlers));
+        }
+
+        registrations.Add(
+            (manifest.SkillId, manifest.Version),
+            new Registration(manifest, ComputeManifestDigest(manifest), handlers));
+    }
+
+    public ValueTask<SkillManifest?> ResolveManifestAsync(
+        string skillId,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        registrations.TryGetValue((skillId, version), out var registration);
+        return ValueTask.FromResult(registration?.Manifest);
+    }
+
+    public async ValueTask<SkillResult> InvokeAsync(
+        SkillInvocation invocation,
+        SkillExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!registrations.TryGetValue((invocation.SkillId, invocation.SkillVersion), out var registration))
+            {
+                return Denied("skill-not-declared", "The requested skill version is not registered.");
+            }
+
+            var suppliedDigest = Encoding.UTF8.GetBytes(invocation.ManifestDigest);
+            var registeredDigest = Encoding.UTF8.GetBytes(registration.ManifestDigest);
+            var currentDigest = Encoding.UTF8.GetBytes(ComputeManifestDigest(registration.Manifest));
+            if (!CryptographicOperations.FixedTimeEquals(suppliedDigest, registeredDigest)
+                || !CryptographicOperations.FixedTimeEquals(currentDigest, registeredDigest))
+            {
+                return Denied("manifest-tampered", "The supplied manifest digest does not match.");
+            }
+
+            var tool = registration.Manifest.Tools.SingleOrDefault(
+                candidate => string.Equals(candidate.Name, invocation.ToolName, StringComparison.Ordinal));
+            if (tool is null || !registration.Handlers.TryGetValue(invocation.ToolName, out var handler))
+            {
+                return Denied("tool-not-declared", "The requested tool is not declared.");
+            }
+
+            if (invocation.TenantId != context.TenantId)
+            {
+                return Denied("wrong-tenant", "The invocation tenant does not match the execution context.");
+            }
+
+            if (!string.Equals(invocation.Purpose, context.Purpose, StringComparison.Ordinal)
+                || !tool.AllowedPurposes.Contains(invocation.Purpose, StringComparer.Ordinal))
+            {
+                return Denied("wrong-purpose", "The purpose is not authorized for this tool.");
+            }
+
+            if (tool.RequiredCapabilities.Any(
+                required => !context.GrantedCapabilities.Contains(required)))
+            {
+                return Denied("capability-denied", "A required capability is not granted.");
+            }
+
+            var schemaFailure = ValidateArguments(tool.InputSchema, invocation.Arguments);
+            if (schemaFailure is not null)
+            {
+                return new SkillResult(SkillResultStatus.Invalid, null, null, schemaFailure);
+            }
+
+            return await handler(invocation, context, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return new SkillResult(
+                SkillResultStatus.Cancelled,
+                null,
+                null,
+                new SkillFailure("cancelled", "The invocation was cancelled."));
+        }
+    }
+
+    public static string ComputeManifestDigest(SkillManifest manifest)
+    {
+        var canonical = new StringBuilder();
+        Append(canonical, manifest.SkillId);
+        Append(canonical, manifest.Version);
+        Append(canonical, manifest.DisplayName);
+
+        foreach (var tool in manifest.Tools.OrderBy(tool => tool.Name, StringComparer.Ordinal))
+        {
+            Append(canonical, tool.Name);
+            Append(canonical, tool.Version);
+            Append(canonical, tool.Description);
+            foreach (var field in tool.InputSchema.OrderBy(field => field.Name, StringComparer.Ordinal))
+            {
+                Append(canonical, field.Name);
+                Append(canonical, field.Kind.ToString());
+                Append(canonical, field.Required ? "1" : "0");
+            }
+
+            foreach (var capability in tool.RequiredCapabilities.Order(StringComparer.Ordinal))
+            {
+                Append(canonical, capability);
+            }
+
+            foreach (var purpose in tool.AllowedPurposes.Order(StringComparer.Ordinal))
+            {
+                Append(canonical, purpose);
+            }
+        }
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical.ToString())));
+    }
+
+    private static SkillFailure? ValidateArguments(
+        IReadOnlyList<ToolFieldSchema> schema,
+        IReadOnlyDictionary<string, JsonElement> arguments)
+    {
+        var declared = schema.Select(field => field.Name).ToHashSet(StringComparer.Ordinal);
+        if (arguments.Keys.Any(argument => !declared.Contains(argument)))
+        {
+            return new("undeclared-argument", "An argument is not declared by the tool schema.");
+        }
+
+        foreach (var field in schema)
+        {
+            if (!arguments.TryGetValue(field.Name, out var value))
+            {
+                if (field.Required)
+                {
+                    return new("missing-argument", $"Required argument '{field.Name}' is missing.");
+                }
+
+                continue;
+            }
+
+            if (!Matches(field.Kind, value.ValueKind))
+            {
+                return new("argument-type", $"Argument '{field.Name}' has the wrong type.");
+            }
+        }
+
+        return null;
+    }
+
+    private static bool Matches(ToolValueKind expected, JsonValueKind actual) =>
+        expected switch
+        {
+            ToolValueKind.Text => actual == JsonValueKind.String,
+            ToolValueKind.Numeric => actual == JsonValueKind.Number,
+            ToolValueKind.Logical => actual is JsonValueKind.True or JsonValueKind.False,
+            ToolValueKind.Structured => actual == JsonValueKind.Object,
+            ToolValueKind.Sequence => actual == JsonValueKind.Array,
+            _ => false,
+        };
+
+    private static SkillResult Denied(string code, string message) =>
+        new(SkillResultStatus.Denied, null, null, new SkillFailure(code, message));
+
+    private static void Append(StringBuilder builder, string value) =>
+        builder.Append(value.Length).Append(':').Append(value).Append(';');
+
+    private sealed record Registration(
+        SkillManifest Manifest,
+        string ManifestDigest,
+        IReadOnlyDictionary<string, SkillToolHandler> Handlers);
+}

--- a/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
+++ b/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
@@ -11,7 +11,13 @@ public sealed class DependencyDirectionTests
         {
             "Andreja.Platform.Contracts",
             // Framework-neutral facade emitted for fundamental BCL types.
+            "System.Collections",
+            "System.Linq",
+            "System.Memory",
             "System.Runtime",
+            "System.Security.Cryptography",
+            "System.Text.Json",
+            "System.Threading",
         };
 
     [Fact]

--- a/tests/Andreja.UnitTests/Andreja.UnitTests.csproj
+++ b/tests/Andreja.UnitTests/Andreja.UnitTests.csproj
@@ -20,6 +20,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Andreja.AppHost\Andreja.AppHost.csproj" />
+    <ProjectReference Include="..\..\src\Andreja.Platform.Contracts\Andreja.Platform.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Modules\Andreja.Modules\Andreja.Modules.csproj" />
+    <ProjectReference Include="..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Andreja.UnitTests/AssistantProviderTests.cs
+++ b/tests/Andreja.UnitTests/AssistantProviderTests.cs
@@ -1,0 +1,98 @@
+using Andreja.Adapters.Assistant.OpenAiCompatible;
+using Andreja.Modules.Assistant;
+using Andreja.Platform.Contracts.Assistant;
+using Andreja.Platform.Contracts.Skills;
+
+namespace Andreja.UnitTests;
+
+public sealed class AssistantProviderTests
+{
+    [Fact]
+    public async Task DeterministicProviderReturnsStructuredFailure()
+    {
+        var expected = Response(
+            AssistantResponseStatus.Failed,
+            new("provider-unavailable", "Provider is unavailable.", true));
+        var provider = new DeterministicAssistantProvider(Capabilities(), (_, _) => ValueTask.FromResult(expected));
+        await using var session = await provider.CreateSessionAsync(SessionRequest(), CancellationToken.None);
+
+        var actual = await session.CompleteAsync(Request(), CancellationToken.None);
+
+        Assert.Equal(expected, actual);
+        Assert.Equal("provider-unavailable", actual.Failure?.Code);
+    }
+
+    [Fact]
+    public async Task SessionCancellationStopsInFlightRequest()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new DeterministicAssistantProvider(
+            Capabilities(),
+            async (_, token) =>
+            {
+                started.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return Response(AssistantResponseStatus.Completed, null);
+            });
+        await using var session = await provider.CreateSessionAsync(SessionRequest(), CancellationToken.None);
+
+        var completion = session.CompleteAsync(Request(), CancellationToken.None).AsTask();
+        await started.Task;
+        await session.CancelAsync(CancellationToken.None);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => completion);
+    }
+
+    [Fact]
+    public void OpenAiProfileRejectsUnsafeEndpointAndSecretInsteadOfHandle()
+    {
+        var unsafeEndpoint = Profile() with { Endpoint = new("http://api.example.test/v1") };
+        var rawSecret = Profile() with { CredentialHandle = "sk-not-a-handle" };
+
+        Assert.Throws<ArgumentException>(() => OpenAiCompatibleAssistantAdapter.Validate(unsafeEndpoint));
+        Assert.Throws<ArgumentException>(() => OpenAiCompatibleAssistantAdapter.Validate(rawSecret));
+        Assert.Equal(Profile(), OpenAiCompatibleAssistantAdapter.Validate(Profile()));
+    }
+
+    private static AssistantProviderCapabilities Capabilities() =>
+        new("fake", "deterministic-v1", AssistantCapability.TextCompletion | AssistantCapability.Cancellation);
+
+    private static AssistantSessionRequest SessionRequest() =>
+        new(
+            Guid.CreateVersion7(),
+            new(Guid.CreateVersion7(), Guid.CreateVersion7(), "task.capture"),
+            [Tool()]);
+
+    private static AssistantRequest Request() =>
+        new(Guid.CreateVersion7(), "Create a task.", ["open-loops.propose-task"]);
+
+    private static ToolDefinition Tool() =>
+        new(
+            "open-loops.propose-task",
+            "1",
+            "Propose a task.",
+            [],
+            ["tasks.propose"],
+            ["task.capture"]);
+
+    private static AssistantResponse Response(
+        AssistantResponseStatus status,
+        AssistantFailure? failure) =>
+        new(
+            Guid.CreateVersion7(),
+            status,
+            null,
+            [],
+            new("fake", "deterministic-v1", 4, 2, TimeSpan.Zero, status.ToString(), 0, 0),
+            failure);
+
+    private static AssistantProviderProfile Profile() =>
+        new(
+            new Uri("https://api.example.test/v1"),
+            "compatible-model",
+            "credential://assistant/byok-primary",
+            TimeSpan.FromSeconds(30),
+            "Provider retention disclosed.",
+            10_000,
+            2_000);
+}

--- a/tests/Andreja.UnitTests/ConsentAndDisclosureTests.cs
+++ b/tests/Andreja.UnitTests/ConsentAndDisclosureTests.cs
@@ -1,0 +1,174 @@
+using Andreja.Modules.Sharing;
+using Andreja.Platform.Contracts.Sharing;
+
+namespace Andreja.UnitTests;
+
+public sealed class ConsentAndDisclosureTests
+{
+    [Fact]
+    public void BilateralConsentRequiresReceiverAcceptanceAndOffererActivation()
+    {
+        var (record, offerer, receiver, now) = CreateConsent();
+
+        var accepted = ConsentPolicy.Transition(
+            record,
+            ConsentState.Accepted,
+            receiver,
+            now.AddMinutes(1));
+        var active = ConsentPolicy.Transition(
+            accepted,
+            ConsentState.Active,
+            offerer,
+            now.AddMinutes(2));
+
+        Assert.Equal(
+            [ConsentState.Offered, ConsentState.Accepted, ConsentState.Active],
+            active.Timeline.Select(item => item.State));
+        Assert.Throws<InvalidOperationException>(
+            () => ConsentPolicy.Transition(record, ConsentState.Active, offerer, now.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void GrantRequiresActiveConsentAndExactPurpose()
+    {
+        var (record, offerer, receiver, now) = CreateConsent();
+        var active = ConsentPolicy.Transition(
+            ConsentPolicy.Transition(record, ConsentState.Accepted, receiver, now.AddMinutes(1)),
+            ConsentState.Active,
+            offerer,
+            now.AddMinutes(2));
+        var grant = new Grant(
+            record.GrantId,
+            "1",
+            Guid.CreateVersion7(),
+            "trip/7",
+            "itinerary",
+            receiver,
+            "trip.plan",
+            DisclosureLevel.Summary,
+            new HashSet<string>(["read"], StringComparer.Ordinal),
+            now,
+            now.AddHours(1),
+            false,
+            null,
+            record.ConsentId);
+
+        Assert.True(ConsentPolicy.IsGrantActive(
+            grant,
+            active,
+            receiver,
+            "trip.plan",
+            "read",
+            now.AddMinutes(3)));
+        Assert.False(ConsentPolicy.IsGrantActive(
+            grant,
+            active,
+            receiver,
+            "profile.publish",
+            "read",
+            now.AddMinutes(3)));
+    }
+
+    [Fact]
+    public void ActiveConsentCanBeRevokedButNotReactivated()
+    {
+        var (record, offerer, receiver, now) = CreateConsent();
+        var active = ConsentPolicy.Transition(
+            ConsentPolicy.Transition(record, ConsentState.Accepted, receiver, now.AddMinutes(1)),
+            ConsentState.Active,
+            offerer,
+            now.AddMinutes(2));
+
+        var revoked = ConsentPolicy.Transition(
+            active,
+            ConsentState.Revoked,
+            receiver,
+            now.AddMinutes(3));
+
+        Assert.Equal(ConsentState.Revoked, revoked.Timeline[^1].State);
+        Assert.Throws<InvalidOperationException>(
+            () => ConsentPolicy.Transition(
+                revoked,
+                ConsentState.Active,
+                offerer,
+                now.AddMinutes(4)));
+    }
+
+    [Fact]
+    public void DisclosurePolicyCanReduceButNeverWiden()
+    {
+        Assert.Equal(
+            DisclosureLevel.Timing,
+            DisclosurePolicy.Reduce(
+                DisclosureLevel.Full,
+                DisclosureLevel.Summary,
+                DisclosureLevel.Timing));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => DisclosurePolicy.Reduce(
+                (DisclosureLevel)99,
+                DisclosureLevel.Full,
+                DisclosureLevel.Full));
+    }
+
+    [Fact]
+    public async Task ShareAuditRecordsAllowAndDenyWithoutPayloadContent()
+    {
+        var sink = new InMemoryShareAuditSink();
+        var (_, actor, peer, now) = CreateConsent();
+        var tenant = Guid.CreateVersion7();
+        var grant = Guid.CreateVersion7();
+        var consent = Guid.CreateVersion7();
+        var allowed = new ShareAuditEntry(
+            Guid.CreateVersion7(),
+            "1",
+            tenant,
+            actor,
+            peer,
+            grant,
+            consent,
+            "trip/7",
+            "itinerary",
+            "trip.plan",
+            DisclosureLevel.Timing,
+            "read",
+            ShareAuditOutcome.Allowed,
+            "ENVELOPE-DIGEST",
+            "PAYLOAD-DIGEST",
+            now);
+        var denied = allowed with
+        {
+            AuditId = Guid.CreateVersion7(),
+            Outcome = ShareAuditOutcome.Denied,
+            DisclosureLevel = DisclosureLevel.Full,
+        };
+
+        await sink.AppendAsync(allowed, CancellationToken.None);
+        await sink.AppendAsync(denied, CancellationToken.None);
+
+        Assert.Equal([ShareAuditOutcome.Allowed, ShareAuditOutcome.Denied], sink.Entries.Select(x => x.Outcome));
+        Assert.All(sink.Entries, entry => Assert.DoesNotContain("content", entry.ToString(), StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static (ConsentRecord Record, Guid Offerer, Guid Receiver, DateTimeOffset Now)
+        CreateConsent()
+    {
+        var now = new DateTimeOffset(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
+        var offerer = Guid.CreateVersion7();
+        var receiver = Guid.CreateVersion7();
+        var grantId = Guid.CreateVersion7();
+        var record = new ConsentRecord(
+            Guid.CreateVersion7(),
+            "1",
+            grantId,
+            offerer,
+            receiver,
+            new(
+                "trip.plan",
+                DisclosureLevel.Summary,
+                new HashSet<string>(["read"], StringComparer.Ordinal),
+                now,
+                now.AddHours(1)),
+            [new(ConsentState.Offered, offerer, now)]);
+        return (record, offerer, receiver, now);
+    }
+}

--- a/tests/Andreja.UnitTests/PeerChannelConformanceTests.cs
+++ b/tests/Andreja.UnitTests/PeerChannelConformanceTests.cs
@@ -1,0 +1,123 @@
+using Andreja.Modules.Channels;
+using Andreja.Platform.Contracts.Peers;
+using System.Text;
+
+namespace Andreja.UnitTests;
+
+public sealed class PeerChannelConformanceTests
+{
+    private static readonly byte[] Key = Encoding.UTF8.GetBytes("local-conformance-key-32-bytes!!");
+    private static readonly Guid Sender = Guid.Parse("018f0000-0000-7000-8000-000000000001");
+    private static readonly Guid Recipient = Guid.Parse("018f0000-0000-7000-8000-000000000002");
+    private static readonly Guid Grant = Guid.Parse("018f0000-0000-7000-8000-000000000003");
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void CanonicalizationAndSignatureAreDeterministic()
+    {
+        var envelope = CreateEnvelope();
+
+        var first = LocalPeerChannel.SignFixture(envelope, Key);
+        var second = LocalPeerChannel.SignFixture(envelope, Key);
+
+        Assert.Equal(first.Signature, second.Signature);
+        Assert.Equal("OCz+dPbQLsy0izfmzUAZn3TX2y0UxeYGgnsRbayRVsw=", first.Signature);
+        Assert.Equal(
+            Convert.ToHexString(LocalPeerChannel.Canonicalize(first)),
+            Convert.ToHexString(LocalPeerChannel.Canonicalize(second)));
+    }
+
+    [Fact]
+    public async Task TamperAndExactReplayAreRejected()
+    {
+        var channel = CreateChannel();
+        var signed = LocalPeerChannel.SignFixture(CreateEnvelope(), Key);
+
+        var accepted = await channel.ReceiveAsync(signed, Context(), CancellationToken.None);
+        var replay = await channel.ReceiveAsync(signed, Context(), CancellationToken.None);
+        var tampered = await channel.ReceiveAsync(
+            signed with { PayloadDigest = new string('B', 64) },
+            Context(),
+            CancellationToken.None);
+
+        Assert.Equal(PeerReceiveOutcome.Accepted, accepted.Outcome);
+        Assert.True(accepted.EffectApplied);
+        Assert.Equal(PeerReceiveOutcome.Replay, replay.Outcome);
+        Assert.Equal(PeerReceiveOutcome.InvalidSignature, tampered.Outcome);
+    }
+
+    [Theory]
+    [InlineData("audience", PeerReceiveOutcome.WrongAudience)]
+    [InlineData("purpose", PeerReceiveOutcome.WrongPurpose)]
+    [InlineData("expiry", PeerReceiveOutcome.Expired)]
+    [InlineData("version", PeerReceiveOutcome.InvalidVersion)]
+    [InlineData("algorithm", PeerReceiveOutcome.UnknownAlgorithm)]
+    [InlineData("key", PeerReceiveOutcome.UnknownKey)]
+    public async Task EnvelopePolicyFailsClosed(string mutation, PeerReceiveOutcome expected)
+    {
+        var envelope = CreateEnvelope();
+        envelope = mutation switch
+        {
+            "audience" => envelope with { RecipientId = Guid.CreateVersion7() },
+            "purpose" => envelope with { Purpose = "profile.publish" },
+            "expiry" => envelope with { ExpiresAt = Now },
+            "version" => envelope with { ProtocolVersion = "andreja.peer/2" },
+            "algorithm" => envelope with { SigningAlgorithm = "RS256" },
+            "key" => envelope with { KeyId = "unknown-key" },
+            _ => throw new ArgumentOutOfRangeException(nameof(mutation)),
+        };
+        var signed = LocalPeerChannel.SignFixture(envelope, Key);
+
+        var result = await CreateChannel().ReceiveAsync(signed, Context(), CancellationToken.None);
+
+        Assert.Equal(expected, result.Outcome);
+        Assert.False(result.EffectApplied);
+    }
+
+    [Fact]
+    public async Task NewEnvelopeWithSameOperationIsIdempotent()
+    {
+        var channel = CreateChannel();
+        var first = LocalPeerChannel.SignFixture(CreateEnvelope(), Key);
+        var retry = LocalPeerChannel.SignFixture(
+            CreateEnvelope() with
+            {
+                EnvelopeId = Guid.Parse("018f0000-0000-7000-8000-000000000099"),
+                Nonce = "nonce-002",
+            },
+            Key);
+
+        var accepted = await channel.ReceiveAsync(first, Context(), CancellationToken.None);
+        var idempotent = await channel.ReceiveAsync(retry, Context(), CancellationToken.None);
+
+        Assert.Equal(PeerReceiveOutcome.Accepted, accepted.Outcome);
+        Assert.Equal(PeerReceiveOutcome.IdempotentReplay, idempotent.Outcome);
+        Assert.False(idempotent.EffectApplied);
+        Assert.Equal(accepted.ReceiptId, idempotent.ReceiptId);
+    }
+
+    private static LocalPeerChannel CreateChannel() =>
+        new(new Dictionary<string, byte[]> { ["peer-key-1"] = Key });
+
+    private static PeerReceiveContext Context() =>
+        new(Sender, Recipient, Grant, "trip.plan", Now);
+
+    private static SignedPeerEnvelope CreateEnvelope() =>
+        new(
+            LocalPeerChannel.ProtocolVersion,
+            Guid.Parse("018f0000-0000-7000-8000-000000000010"),
+            Sender,
+            Recipient,
+            Grant,
+            "trip.plan",
+            "nonce-001",
+            "operation-001",
+            Now.AddMinutes(-1),
+            Now.AddMinutes(4),
+            "andreja.trip-summary/1",
+            new string('A', 64),
+            LocalPeerChannel.FixtureAlgorithm,
+            "peer-key-1",
+            string.Empty);
+}

--- a/tests/Andreja.UnitTests/ProposalLifecycleTests.cs
+++ b/tests/Andreja.UnitTests/ProposalLifecycleTests.cs
@@ -1,0 +1,127 @@
+using Andreja.Modules.Proposals;
+using Andreja.Platform.Contracts.Proposals;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Andreja.UnitTests;
+
+public sealed class ProposalLifecycleTests
+{
+    [Fact]
+    public async Task ConfirmationRetryIsIdempotentAndAuditedOncePerAttempt()
+    {
+        var store = new InMemoryProposalStore();
+        var proposal = CreateProposal();
+        Assert.True(await store.TryCreateAsync(proposal, CancellationToken.None));
+        var request = Request(proposal, ProposalAction.Confirm, "confirm-1", proposal.CreatedAt.AddMinutes(1));
+
+        var first = await store.TryTransitionAsync(request, CancellationToken.None);
+        var retry = await store.TryTransitionAsync(
+            request with { OccurredAt = request.OccurredAt.AddSeconds(5) },
+            CancellationToken.None);
+
+        Assert.Equal(ProposalTransitionOutcome.Applied, first.Outcome);
+        Assert.Equal(ProposalState.Confirmed, first.Proposal?.State);
+        Assert.Equal(ProposalTransitionOutcome.IdempotentReplay, retry.Outcome);
+        Assert.Single(store.AuditEntries);
+        Assert.Equal(proposal.ActorId, store.AuditEntries[0].ActorId);
+        Assert.Equal(proposal.Source.Reference, store.AuditEntries[0].SourceReference);
+    }
+
+    [Fact]
+    public async Task ExpiredProposalCannotBeConfirmed()
+    {
+        var store = new InMemoryProposalStore();
+        var proposal = CreateProposal();
+        Assert.True(await store.TryCreateAsync(proposal, CancellationToken.None));
+
+        var result = await store.TryTransitionAsync(
+            Request(proposal, ProposalAction.Confirm, "late", proposal.ExpiresAt),
+            CancellationToken.None);
+
+        Assert.Equal(ProposalTransitionOutcome.Expired, result.Outcome);
+        Assert.Equal(ProposalState.Expired, result.Proposal?.State);
+    }
+
+    [Fact]
+    public async Task ConcurrentTransitionsApplyAtMostOnce()
+    {
+        var store = new InMemoryProposalStore();
+        var proposal = CreateProposal();
+        Assert.True(await store.TryCreateAsync(proposal, CancellationToken.None));
+
+        var attempts = Enumerable.Range(0, 8)
+            .Select(index => store.TryTransitionAsync(
+                Request(
+                    proposal,
+                    ProposalAction.Confirm,
+                    $"confirm-{index}",
+                    proposal.CreatedAt.AddMinutes(1)),
+                CancellationToken.None).AsTask());
+        var results = await Task.WhenAll(attempts);
+
+        Assert.Single(results, result => result.Outcome == ProposalTransitionOutcome.Applied);
+        Assert.All(
+            results.Where(result => result.Outcome != ProposalTransitionOutcome.Applied),
+            result => Assert.Equal(ProposalTransitionOutcome.Conflict, result.Outcome));
+    }
+
+    [Theory]
+    [InlineData(ProposalAction.Reject, ProposalState.Rejected)]
+    [InlineData(ProposalAction.Cancel, ProposalState.Cancelled)]
+    public async Task TerminalActionsPreserveExactOperation(
+        ProposalAction action,
+        ProposalState expectedState)
+    {
+        var store = new InMemoryProposalStore();
+        var proposal = CreateProposal();
+        Assert.True(await store.TryCreateAsync(proposal, CancellationToken.None));
+
+        var result = await store.TryTransitionAsync(
+            Request(proposal, action, action.ToString(), proposal.CreatedAt.AddMinutes(1)),
+            CancellationToken.None);
+
+        Assert.Equal(expectedState, result.Proposal?.State);
+        Assert.Equal(proposal.Operation, result.Proposal?.Operation);
+        Assert.Equal(proposal.Diff, result.Proposal?.Diff);
+    }
+
+    private static Proposal CreateProposal()
+    {
+        var created = new DateTimeOffset(2026, 8, 23, 12, 0, 0, TimeSpan.Zero);
+        var actor = Guid.CreateVersion7();
+        const string canonical = """{"title":"Book dentist"}""";
+        return new(
+            Guid.CreateVersion7(),
+            1,
+            Guid.CreateVersion7(),
+            actor,
+            "task.capture",
+            new("assistant", "session-7", actor),
+            new(
+                "open-loops.create-task",
+                "tasks/new",
+                canonical,
+                Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))),
+            new(
+                "{}",
+                canonical),
+            created,
+            created.AddMinutes(5),
+            ProposalState.Pending);
+    }
+
+    private static ProposalTransitionRequest Request(
+        Proposal proposal,
+        ProposalAction action,
+        string idempotencyKey,
+        DateTimeOffset occurredAt) =>
+        new(
+            proposal.ProposalId,
+            proposal.Version,
+            proposal.TenantId,
+            proposal.ActorId,
+            action,
+            idempotencyKey,
+            occurredAt);
+}

--- a/tests/Andreja.UnitTests/ProposalLifecycleTests.cs
+++ b/tests/Andreja.UnitTests/ProposalLifecycleTests.cs
@@ -8,7 +8,7 @@ namespace Andreja.UnitTests;
 public sealed class ProposalLifecycleTests
 {
     [Fact]
-    public async Task ConfirmationRetryIsIdempotentAndAuditedOncePerAttempt()
+    public async Task ConfirmationRetryIsIdempotentAndAuditedOnceForAppliedEffect()
     {
         var store = new InMemoryProposalStore();
         var proposal = CreateProposal();
@@ -41,6 +41,72 @@ public sealed class ProposalLifecycleTests
 
         Assert.Equal(ProposalTransitionOutcome.Expired, result.Outcome);
         Assert.Equal(ProposalState.Expired, result.Proposal?.State);
+    }
+
+    public static TheoryData<string, ProposalTransitionOutcome> NegativeReplayCases =>
+        new()
+        {
+            { "wrong-actor", ProposalTransitionOutcome.Denied },
+            { "wrong-tenant", ProposalTransitionOutcome.Denied },
+            { "not-found", ProposalTransitionOutcome.NotFound },
+            { "expired", ProposalTransitionOutcome.Expired },
+            { "conflict", ProposalTransitionOutcome.Conflict },
+            { "invalid-state", ProposalTransitionOutcome.InvalidState },
+        };
+
+    [Theory]
+    [MemberData(nameof(NegativeReplayCases))]
+    public async Task NegativeTransitionRetryPreservesOriginalOutcomeWithoutDuplicateEffects(
+        string scenario,
+        ProposalTransitionOutcome expectedOutcome)
+    {
+        var store = new InMemoryProposalStore();
+        var proposal = CreateProposal();
+        ProposalTransitionRequest request;
+
+        if (scenario == "not-found")
+        {
+            request = Request(proposal, ProposalAction.Confirm, scenario, proposal.CreatedAt.AddMinutes(1))
+                with
+            { ProposalId = Guid.CreateVersion7() };
+        }
+        else
+        {
+            Assert.True(await store.TryCreateAsync(proposal, CancellationToken.None));
+            request = Request(proposal, ProposalAction.Confirm, scenario, proposal.CreatedAt.AddMinutes(1));
+
+            request = scenario switch
+            {
+                "wrong-actor" => request with { ActorId = Guid.CreateVersion7() },
+                "wrong-tenant" => request with { TenantId = Guid.CreateVersion7() },
+                "expired" => request with { OccurredAt = proposal.ExpiresAt },
+                "conflict" => request with { ExpectedVersion = proposal.Version + 1 },
+                "invalid-state" => await CreateInvalidStateRequestAsync(store, proposal, request),
+                _ => throw new ArgumentOutOfRangeException(nameof(scenario)),
+            };
+        }
+
+        var first = await store.TryTransitionAsync(request, CancellationToken.None);
+        var stateAfterFirst = await store.GetAsync(
+            proposal.TenantId,
+            proposal.ProposalId,
+            CancellationToken.None);
+        var auditCountAfterFirst = store.AuditEntries.Count;
+
+        var retry = await store.TryTransitionAsync(
+            request with { OccurredAt = request.OccurredAt.AddSeconds(5) },
+            CancellationToken.None);
+        var stateAfterRetry = await store.GetAsync(
+            proposal.TenantId,
+            proposal.ProposalId,
+            CancellationToken.None);
+
+        Assert.Equal(expectedOutcome, first.Outcome);
+        Assert.Equal(expectedOutcome, retry.Outcome);
+        Assert.NotEqual(ProposalTransitionOutcome.IdempotentReplay, retry.Outcome);
+        Assert.Equal(first.Proposal, retry.Proposal);
+        Assert.Equal(stateAfterFirst, stateAfterRetry);
+        Assert.Equal(auditCountAfterFirst, store.AuditEntries.Count);
     }
 
     [Fact]
@@ -124,4 +190,20 @@ public sealed class ProposalLifecycleTests
             action,
             idempotencyKey,
             occurredAt);
+
+    private static async Task<ProposalTransitionRequest> CreateInvalidStateRequestAsync(
+        InMemoryProposalStore store,
+        Proposal proposal,
+        ProposalTransitionRequest request)
+    {
+        var applied = await store.TryTransitionAsync(
+            Request(
+                proposal,
+                ProposalAction.Confirm,
+                "invalid-state-prerequisite",
+                proposal.CreatedAt.AddSeconds(30)),
+            CancellationToken.None);
+        Assert.Equal(ProposalTransitionOutcome.Applied, applied.Outcome);
+        return request with { ExpectedVersion = applied.Proposal!.Version };
+    }
 }

--- a/tests/Andreja.UnitTests/SkillHostTests.cs
+++ b/tests/Andreja.UnitTests/SkillHostTests.cs
@@ -1,0 +1,147 @@
+using Andreja.Modules.Skills;
+using Andreja.Platform.Contracts.Skills;
+using System.Text.Json;
+
+namespace Andreja.UnitTests;
+
+public sealed class SkillHostTests
+{
+    [Fact]
+    public async Task HostDeniesUndeclaredTool()
+    {
+        var (host, manifest, context) = CreateHost();
+        var invocation = Invocation(manifest, context) with { ToolName = "open-loops.delete-all" };
+
+        var result = await host.InvokeAsync(invocation, context, CancellationToken.None);
+
+        Assert.Equal(SkillResultStatus.Denied, result.Status);
+        Assert.Equal("tool-not-declared", result.Failure?.Code);
+    }
+
+    [Fact]
+    public async Task HostDeniesWrongPurposeAndTenant()
+    {
+        var (host, manifest, context) = CreateHost();
+        var wrongPurpose = Invocation(manifest, context) with { Purpose = "profile.publish" };
+        var wrongTenant = Invocation(manifest, context) with { TenantId = Guid.CreateVersion7() };
+
+        var purposeResult = await host.InvokeAsync(wrongPurpose, context, CancellationToken.None);
+        var tenantResult = await host.InvokeAsync(wrongTenant, context, CancellationToken.None);
+
+        Assert.Equal("wrong-purpose", purposeResult.Failure?.Code);
+        Assert.Equal("wrong-tenant", tenantResult.Failure?.Code);
+    }
+
+    [Fact]
+    public async Task HostDeniesManifestTamperingAndMissingCapability()
+    {
+        var (host, manifest, context) = CreateHost();
+        var invocation = Invocation(manifest, context);
+        var tampered = invocation with { ManifestDigest = new string('0', 64) };
+        var noGrant = context with { GrantedCapabilities = new HashSet<string>() };
+
+        var tamperResult = await host.InvokeAsync(tampered, context, CancellationToken.None);
+        var grantResult = await host.InvokeAsync(invocation, noGrant, CancellationToken.None);
+
+        Assert.Equal("manifest-tampered", tamperResult.Failure?.Code);
+        Assert.Equal("capability-denied", grantResult.Failure?.Code);
+    }
+
+    [Fact]
+    public async Task HostReturnsStructuredCancellation()
+    {
+        var (host, manifest, context) = CreateHost();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var result = await host.InvokeAsync(Invocation(manifest, context), context, cancellation.Token);
+
+        Assert.Equal(SkillResultStatus.Cancelled, result.Status);
+        Assert.Equal("cancelled", result.Failure?.Code);
+    }
+
+    [Fact]
+    public async Task HostDetectsRegisteredManifestMutation()
+    {
+        var toolList = new List<ToolDefinition>
+        {
+            new(
+                "open-loops.propose-task",
+                "1",
+                "Propose a task without writing it.",
+                [new("title", ToolValueKind.Text, true)],
+                ["tasks.propose"],
+                ["task.capture"]),
+        };
+        var manifest = new SkillManifest("open-loops", "1", "Open Loops", toolList);
+        var host = new InMemorySkillHost();
+        host.Register(
+            manifest,
+            new Dictionary<string, SkillToolHandler>
+            {
+                ["open-loops.propose-task"] = (_, _, _) =>
+                    ValueTask.FromResult(new SkillResult(SkillResultStatus.Completed, null, null, null)),
+            });
+        var context = new SkillExecutionContext(
+            Guid.CreateVersion7(),
+            Guid.CreateVersion7(),
+            "task.capture",
+            new HashSet<string>(["tasks.propose"]));
+        var invocation = Invocation(manifest, context);
+        toolList[0] = toolList[0] with { AllowedPurposes = ["profile.publish"] };
+
+        var result = await host.InvokeAsync(invocation, context, CancellationToken.None);
+
+        Assert.Equal("manifest-tampered", result.Failure?.Code);
+    }
+
+    private static (InMemorySkillHost Host, SkillManifest Manifest, SkillExecutionContext Context) CreateHost()
+    {
+        var manifest = new SkillManifest(
+            "open-loops",
+            "1",
+            "Open Loops",
+            [
+                new(
+                    "open-loops.propose-task",
+                    "1",
+                    "Propose a task without writing it.",
+                    [new("title", ToolValueKind.Text, true)],
+                    ["tasks.propose"],
+                    ["task.capture"]),
+            ]);
+        var host = new InMemorySkillHost();
+        host.Register(
+            manifest,
+            new Dictionary<string, SkillToolHandler>(StringComparer.Ordinal)
+            {
+                ["open-loops.propose-task"] = (_, _, _) =>
+                    ValueTask.FromResult(new SkillResult(
+                        SkillResultStatus.Completed,
+                        JsonSerializer.SerializeToElement(new { accepted = true }),
+                        null,
+                        null)),
+            });
+        var context = new SkillExecutionContext(
+            Guid.CreateVersion7(),
+            Guid.CreateVersion7(),
+            "task.capture",
+            new HashSet<string>(["tasks.propose"], StringComparer.Ordinal));
+        return (host, manifest, context);
+    }
+
+    private static SkillInvocation Invocation(
+        SkillManifest manifest,
+        SkillExecutionContext context) =>
+        new(
+            manifest.SkillId,
+            manifest.Version,
+            "open-loops.propose-task",
+            context.TenantId,
+            context.Purpose,
+            new Dictionary<string, JsonElement>
+            {
+                ["title"] = JsonSerializer.SerializeToElement("Book dentist"),
+            },
+            InMemorySkillHost.ComputeManifestDigest(manifest));
+}


### PR DESCRIPTION
## Why

Closes #43

Implements the provider-neutral assistant, permissioned skill, proposal, consent/disclosure, audit, and local peer-envelope seams required by ADR 0004. Working as Seven of Nine (Assistant, Skills, Semantic Graph and Federation Lead).

## Approach

- Add application-owned assistant/session, skill/tool manifest, proposal, grant/consent/share-audit, disclosure, and peer-channel contracts with only BCL types.
- Add deterministic assistant and skill hosts, concurrency-safe in-memory proposal/audit fixtures, bilateral consent policy, and local signed-envelope conformance implementation.
- Validate OpenAI-compatible endpoints and opaque credential handles; use an injected transport boundary and make no external model calls.
- Keep AppHost composition, UI, persistence, migrations, discovery, relay, and live federation out of scope.
- Preserve each failed proposal transition outcome on exact retry; only a prior successful transition returns `IdempotentReplay`.

## Charter impact

Preserves human agency through explicit proposal confirmation/rejection/cancellation, data dignity through purpose/tenant/capability checks and content-free audit/usage contracts, and AI safety through exact tool allowlists. Local deterministic fixtures avoid model/network spend. Tuvok/Deanna/Data review remains appropriate for security, consent, and conformance evidence; unknown versions, purposes, audiences, grants, disclosure values, signatures, and replays fail closed.

## Validation

- `dotnet restore Andreja.slnx` — passed
- `dotnet format Andreja.slnx --no-restore --verify-no-changes --verbosity minimal` — passed
- `dotnet build Andreja.slnx --no-restore --nologo` — passed, 0 warnings/errors
- `dotnet test Andreja.slnx --no-build --no-restore --nologo` — passed, 45 tests (35 unit, 10 architecture)
- `dotnet test tests/Andreja.UnitTests/Andreja.UnitTests.csproj --no-build --no-restore --filter FullyQualifiedName~ProposalLifecycleTests` — passed, 11 tests
- Deterministic only; no live provider or federation calls

## Gates

- [x] Architecture/contract impact recorded
- [x] Security/privacy impact recorded; specialist review requested before merge
- [x] Cost/operability impact recorded; no external calls or package additions
- [x] Company charter impact recorded
- [x] Applicable restore/build/test/format checks passed
- [x] User help/release notes not applicable: contract-only Phase 1A slice
- [x] No personal data, prompts, credentials, or connector content included

## Stack

- Parent: #46
- Base: `squad/39-phase1a-foundation`
- Verified base SHA: `ef5076b2fdd20a4d1ff976e570e4f47141556dd3`
- Layer: assistant/skill/proposal contracts after foundation