### PR TITLE
Fix migrated repository links

### DIFF
--- a/docs/adr/0001-phase-1a-modular-boundaries.md
+++ b/docs/adr/0001-phase-1a-modular-boundaries.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 - **Governing:** [Platform plan](../plan.md#non-negotiable-engineering-principles),
   [company charter](../charter.md#decision-and-launch-enforcement), and
   [ADR 0000](0000-plan-ratification.md)

--- a/docs/adr/0002-phase-1a-identity-tenancy.md
+++ b/docs/adr/0002-phase-1a-identity-tenancy.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 - **Governing:** [Platform plan](../plan.md#identity-tenancy-and-authorization-foundations),
   [company charter](../charter.md#commitments), and
   [ADR 0000](0000-plan-ratification.md)

--- a/docs/adr/0003-phase-1a-persistence-portability.md
+++ b/docs/adr/0003-phase-1a-persistence-portability.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 - **Governing:** [Platform plan](../plan.md#deployment-data-ownership-hosting-and-scale),
   [company charter](../charter.md#commitments), and
   [ADR 0000](0000-plan-ratification.md)

--- a/docs/adr/0004-phase-1a-assistant-skill-channel-contracts.md
+++ b/docs/adr/0004-phase-1a-assistant-skill-channel-contracts.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 - **Governing:** [Platform plan](../plan.md#sharing-consent-and-federation-foundations),
   [company charter](../charter.md#decision-and-launch-enforcement), and
   [ADR 0000](0000-plan-ratification.md)

--- a/docs/adr/0005-phase-1a-self-host-operations.md
+++ b/docs/adr/0005-phase-1a-self-host-operations.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 - **Governing:** [Platform plan](../plan.md#phase-1a---self-hosted-assistant-walking-skeleton),
   [company charter](../charter.md#commitments), and
   [ADR 0000](0000-plan-ratification.md)

--- a/docs/phase-1a/README.md
+++ b/docs/phase-1a/README.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed; Cyrus approval required
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 - **Scope:** Independent self-hosted assistant walking skeleton
 - **Governing:** [Platform plan](../plan.md), [company charter](../charter.md),
   and [ADR 0000](../adr/0000-plan-ratification.md)
@@ -42,10 +42,10 @@ free tier, trial, package installation, or live paid model call.
 The packet was checked against ADR 0000, the plan, the static Squad directives,
 the Spock charter, issue #9, and these available Phase 0 drafts:
 
-- [PR #19 — catalog and launch frameworks](https://github.com/cyrusjamula/Andreja/pull/19)
-- [PR #20 — burn and sponsorship controls](https://github.com/cyrusjamula/Andreja/pull/20)
-- [PR #21 — regulatory applicability](https://github.com/cyrusjamula/Andreja/pull/21)
-- [PR #25 — Phase 1A semantic graph contract](https://github.com/cyrusjamula/Andreja/pull/25)
+- [PR #19 — catalog and launch frameworks](https://github.com/Jamula/Andreja/pull/19)
+- [PR #20 — burn and sponsorship controls](https://github.com/Jamula/Andreja/pull/20)
+- [PR #21 — regulatory applicability](https://github.com/Jamula/Andreja/pull/21)
+- [PR #25 — Phase 1A semantic graph contract](https://github.com/Jamula/Andreja/pull/25)
 
 Draft material is informative until separately reviewed and merged. In
 particular, this packet follows PR #25's proposed relational-source-of-truth

--- a/docs/phase-1a/evidence-gates.md
+++ b/docs/phase-1a/evidence-gates.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 
 This is a phase-scoped acceptance index, not a replacement threat model, privacy
 inventory, testing matrix, or financial ledger. These are internal dogfood gates,
@@ -15,7 +15,7 @@ not public SLAs or production claims.
 | Threat | The plan requires [`docs/threat-model.md`](../plan.md#documentation-structure); until that standalone artifact lands, [Security engineering](../plan.md#security-engineering) is the governing baseline. Tuvok owns challenge. | The threat rows below index the Phase 1A controls and proof that the canonical model must contain. |
 | Privacy | The plan requires [`docs/privacy.md`](../plan.md#documentation-structure); until it lands, [Privacy engineering](../plan.md#privacy-engineering) and the [charter](../charter.md#ethics-and-sustainability-impact-assessment) govern. Deanna Troi owns challenge. | The privacy gate below is a Phase 1A field/test overlay, not a second data inventory. |
 | Testing | The plan requires [`docs/testing-matrix.md`](../plan.md#documentation-structure) and defines the [validation strategy](../plan.md#validation-and-regression-strategy). Data owns challenge. | The table below supplies Phase 1A rows/test IDs to the canonical matrix. |
-| Cost | [PR #20](https://github.com/cyrusjamula/Andreja/pull/20) proposes `docs/cost-model.md` as Quark's canonical ledger/budget source; until merged, the [plan's Cost and FinOps rules](../plan.md#cost-and-finops) govern. | This file only links the Phase 1A usage query and stop checks. It neither duplicates price/SKU figures nor changes PR #20's ledgers or authority. |
+| Cost | [PR #20](https://github.com/Jamula/Andreja/pull/20) proposes `docs/cost-model.md` as Quark's canonical ledger/budget source; until merged, the [plan's Cost and FinOps rules](../plan.md#cost-and-finops) govern. | This file only links the Phase 1A usage query and stop checks. It neither duplicates price/SKU figures nor changes PR #20's ledgers or authority. |
 
 When a canonical artifact is merged, its evidence identifier and revision replace the
 interim plan link here. Conflicts resolve in favor of the governing plan/charter and

--- a/docs/phase-1a/exit-checklist.md
+++ b/docs/phase-1a/exit-checklist.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-23
-- **Issue:** [#9](https://github.com/cyrusjamula/Andreja/issues/9)
+- **Issue:** [#9](https://github.com/Jamula/Andreja/issues/9)
 
 ## Packet approval
 


### PR DESCRIPTION
## Summary

- replace all stale `cyrusjamula/Andreja` issue and pull-request routes in the Phase 1A decision packet and ADRs 0001-0005
- point every repository reference directly to canonical `Jamula/Andreja` routes
- preserve the intentional `cyrusjamula` GitHub Sponsors profile and its migration documentation

Working as Data (Quality Engineering Lead).

## Validation

- `git grep -l 'https://github.com/cyrusjamula/Andreja' -- .` — no matches
- `git grep -l -i 'cyrusjamula' -- .` — only `.github/FUNDING.yml` and `docs/repository-migration.md`
- targeted PowerShell Markdown path/anchor validation — 8 changed Markdown files passed
- `gh api repos/Jamula/Andreja/issues/{9,19,20,21,25}` — canonical issue/PR routes resolved
- `git diff --check` — passed
- no YAML files changed

Closes #51