### PR TITLE
Scope Blazor delegation to the circuit client

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -100,14 +100,18 @@ redirect to an HTML login page. Browser UI challenges redirect only to the exist
 
 Interactive Server components do not forward request cookies or use
 `IHttpContextAccessor`; there is no stable request `HttpContext` after a Blazor
-circuit starts. The typed client's delegating handler reads the circuit's
-`AuthenticationState`, issues a Data Protection-protected, one-minute, single-use
-token for the exact `andreja.internal.open-loops.v1` audience, and sends it to the
-dedicated internal API authentication scheme. The protected token binds tenant, app
-user, principal, subject, issue/expiry times, and nonce. Invalid, expired, replayed,
-wrong-audience, missing, or conflicting identity context fails closed. External API
-callers continue to use the approved Identity cookie/passkey scheme; unsigned
-tenant/principal headers are never accepted.
+circuit starts. `OpenLoopsApiClient` is resolved inside the circuit scope and reads
+that scope's `AuthenticationStateProvider` directly at each call. It issues a Data
+Protection-protected, one-minute, single-use token for the exact
+`andreja.internal.open-loops.v1` audience and attaches it to that request. The
+`IHttpClientFactory` pipeline is pooled and deliberately stateless: no delegating
+handler captures a principal, circuit service, request cookie, or `HttpContext`.
+
+The protected token binds tenant, app user, principal, subject, issue/expiry times,
+and nonce. Invalid, expired, replayed, wrong-audience, missing, or conflicting
+identity context fails closed. External API callers continue to use the approved
+Identity cookie/passkey scheme; unsigned tenant/principal headers are never
+accepted.
 
 The task page disables prerendering so initialization runs once inside the
 authenticated circuit. API, transport, cancellation, and delegation initialization

--- a/docs/operations/self-hosting.md
+++ b/docs/operations/self-hosting.md
@@ -127,8 +127,10 @@ No development sign-in endpoint is mapped in Production, and no header-based or
 automatic fake-auth handler exists.
 
 Interactive Server API calls do not forward browser cookies from `HttpContext`.
-They use a short-lived, one-time, Data Protection-protected circuit delegation
-token accepted only by the internal Open Loops audience. External API requests
+The circuit-scoped typed client reads its own authentication state and attaches a
+fresh, short-lived, one-time, Data Protection-protected delegation token accepted
+only by the internal Open Loops audience. The pooled HTTP handler pipeline is
+stateless and contains no user/circuit-scoped dependency. External API requests
 continue to require the approved Identity cookie/passkey path. Delegation tokens,
 cookies, and authorization headers must never be logged, exported, or copied into
 support evidence.

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -10,7 +10,7 @@ Never report unavailable live dependencies as passed.
 | API and authorization | Anonymous and fake-header rejection, real Development cookie sign-in, antiforgery rejection, authoritative validation, typed DTO lifecycle | `dotnet test Andreja.slnx --no-build` | Automated; no header authentication handler exists |
 | Local sign-in smoke | Anonymous UI redirects to an existing login route with local-only ReturnUrl; explicit Debug+Development cookie sign-in reaches UI/API; Production and Release builds cannot map the Development sign-in endpoint; API challenge is JSON 401/403 without redirects | `dotnet test Andreja.slnx --no-build`; Release build; follow-redirect live smoke | Development fallback automated; production passkey flow blocked separately |
 | Development origin | Committed HTTPS launch profile and `PublicOrigin` both use `https://localhost:5001`; documented command names the profile and development certificate | `dotnet test Andreja.slnx --no-build` | Automated |
-| Interactive circuit delegation | Real `OpenLoopsApiClient` and handler operate with null `HttpContext`; Data Protection token is audience-bound, short-lived, single-use, and claim-complete; wrong audience, expiry, replay, tampering, and conflicting/missing tenant/principal claims fail closed | `dotnet test Andreja.slnx --no-build` | Automated against the real TestServer API and antiforgery filter |
+| Interactive circuit delegation | Two actual DI scopes resolve the production `AddHttpClient` typed client with different circuit authentication providers and concurrently prove tenant/principal isolation while sharing one pooled stateless handler; Data Protection token is audience-bound, short-lived, single-use, and claim-complete; wrong audience, expiry, replay, tampering, and conflicting/missing claims fail closed | `dotnet test Andreja.slnx --no-build` | Automated against the real TestServer API and antiforgery filter with null `HttpContext` |
 | Tenant and principal isolation | Wrong-tenant/wrong-principal proposal, list, complete, and delete negatives | `dotnet test Andreja.slnx --no-build` | Automated in memory |
 | PostgreSQL | Empty migration, durable task lifecycle, idempotent receipts, and two-tenant filtering | `dotnet test tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj` | Required when a disposable `andreja_test_*` database is supplied; otherwise blocked |
 | Architecture | Blazor page injects the typed API client and cannot inject modules, adapters, or EF | `dotnet test Andreja.slnx --no-build` | Automated |
@@ -22,9 +22,12 @@ Never report unavailable live dependencies as passed.
 
 The API integration fixture uses the real cookie scheme through the explicit
 Development-only sign-in endpoint for external API evidence. Its circuit regression
-uses the real typed client, delegation handler, Data Protection token service,
-TestServer API authentication scheme, antiforgery endpoint, and task lifecycle with
-no `HttpContext`. It proves that common fake-auth headers remain unauthorized and
-that the Development endpoint is absent in Production. Architecture tests continue
-to reject fake/test authentication references, cookie-forwarding handlers, and
-`IHttpContextAccessor` dependencies in the interactive client.
+resolves the real typed client from the actual `AddHttpClient` registration in two
+concurrent simulated circuit scopes. The scopes use distinct principals while the
+factory reuses one stateless pooled handler; each sees only its own tasks. The test
+also exercises the Data Protection token service, TestServer API authentication
+scheme, antiforgery endpoint, and complete task lifecycle with no `HttpContext`.
+Common fake-auth headers remain unauthorized and the Development endpoint is absent
+in Production. Architecture tests reject fake/test authentication references,
+cookie-forwarding handlers, and any pooled delegating handler that depends on
+`AuthenticationStateProvider` or `IHttpContextAccessor`.

--- a/src/Andreja.AppHost/OpenLoops/CircuitDelegation.cs
+++ b/src/Andreja.AppHost/OpenLoops/CircuitDelegation.cs
@@ -1,6 +1,5 @@
 using Andreja.AppHost.Identity;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
@@ -201,51 +200,5 @@ public sealed class CircuitDelegationAuthenticationHandler(
                     CircuitDelegation.AuthenticationScheme))
                 : AuthenticateResult.Fail(
                     validation.FailureCode ?? "delegation-token-invalid"));
-    }
-}
-
-public sealed class CircuitDelegationHandler(
-    AuthenticationStateProvider authenticationStateProvider,
-    ICircuitDelegationTokenService tokenService) : DelegatingHandler
-{
-    private string? antiforgeryCookie;
-
-    protected override async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
-    {
-        var authenticationState =
-            await authenticationStateProvider.GetAuthenticationStateAsync();
-        if (authenticationState.User.Identity?.IsAuthenticated != true)
-        {
-            throw new OpenLoopsApiException(
-                "authentication-required",
-                "Sign in again to continue.");
-        }
-
-        request.Headers.Authorization = new(
-            CircuitDelegation.AuthorizationScheme,
-            tokenService.Issue(
-                authenticationState.User,
-                CircuitDelegation.OpenLoopsAudience));
-        if (!string.IsNullOrWhiteSpace(antiforgeryCookie))
-        {
-            request.Headers.TryAddWithoutValidation("Cookie", antiforgeryCookie);
-        }
-
-        var response = await base.SendAsync(request, cancellationToken);
-        if (response.Headers.TryGetValues("Set-Cookie", out var values))
-        {
-            var cookie = values
-                .Select(value => value.Split(';', 2)[0])
-                .LastOrDefault(value =>
-                    value.StartsWith(".AspNetCore.Antiforgery.", StringComparison.Ordinal));
-            if (cookie is not null)
-            {
-                antiforgeryCookie = cookie;
-            }
-        }
-
-        return response;
     }
 }

--- a/src/Andreja.AppHost/OpenLoops/OpenLoopsApiClient.cs
+++ b/src/Andreja.AppHost/OpenLoops/OpenLoopsApiClient.cs
@@ -1,6 +1,8 @@
 using Andreja.Api.Contracts.OpenLoops;
+using Microsoft.AspNetCore.Components.Authorization;
 using System.Net;
 using System.Net.Http.Json;
+using System.Net.Http.Headers;
 
 namespace Andreja.AppHost.OpenLoops;
 
@@ -35,19 +37,23 @@ public interface IOpenLoopsApiClient
     Task<TaskExportDto> ExportAsync(CancellationToken cancellationToken = default);
 }
 
-public sealed class OpenLoopsApiClient(HttpClient httpClient) : IOpenLoopsApiClient
+public sealed class OpenLoopsApiClient(
+    HttpClient httpClient,
+    AuthenticationStateProvider authenticationStateProvider,
+    ICircuitDelegationTokenService tokenService) : IOpenLoopsApiClient
 {
     private string? antiforgeryToken;
+    private string? antiforgeryCookie;
 
     public async Task<IReadOnlyList<TaskDto>> ListAsync(
         CancellationToken cancellationToken = default) =>
-        await httpClient.GetFromJsonAsync<TaskDto[]>(
+        await GetAsync<TaskDto[]>(
             $"{OpenLoopsApi.RoutePrefix}/tasks",
             cancellationToken) ?? [];
 
     public async Task<AssistantProviderDto> GetProviderAsync(
         CancellationToken cancellationToken = default) =>
-        await httpClient.GetFromJsonAsync<AssistantProviderDto>(
+        await GetAsync<AssistantProviderDto>(
             $"{OpenLoopsApi.RoutePrefix}/assistant/provider",
             cancellationToken)
         ?? throw new OpenLoopsApiException(
@@ -106,7 +112,7 @@ public sealed class OpenLoopsApiClient(HttpClient httpClient) : IOpenLoopsApiCli
 
     public async Task<TaskExportDto> ExportAsync(
         CancellationToken cancellationToken = default) =>
-        await httpClient.GetFromJsonAsync<TaskExportDto>(
+        await GetAsync<TaskExportDto>(
             $"{OpenLoopsApi.RoutePrefix}/export",
             cancellationToken)
         ?? throw new OpenLoopsApiException("invalid-response", "The export response was empty.");
@@ -125,28 +131,94 @@ public sealed class OpenLoopsApiClient(HttpClient httpClient) : IOpenLoopsApiCli
             request.Content = JsonContent.Create(content);
         }
 
-        using var response = await httpClient.SendAsync(request, cancellationToken);
+        using var response = await SendAuthenticatedAsync(request, cancellationToken);
         if (response.StatusCode == HttpStatusCode.BadRequest)
         {
             antiforgeryToken = null;
         }
 
-        if (!response.IsSuccessStatusCode)
-        {
-            var error = await response.Content.ReadFromJsonAsync<ApiErrorDto>(
-                cancellationToken: cancellationToken);
-            throw new OpenLoopsApiException(
-                error?.Code ?? $"http-{(int)response.StatusCode}",
-                error?.Message ?? "The request could not be completed.");
-        }
-
+        await EnsureSuccessAsync(response, cancellationToken);
         return await response.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken)
             ?? throw new OpenLoopsApiException("invalid-response", "The response was empty.");
     }
 
+    private async Task<T?> GetAsync<T>(
+        string route,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        using var response = await SendAuthenticatedAsync(request, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+        return await response.Content.ReadFromJsonAsync<T>(
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> SendAuthenticatedAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var authenticationState =
+            await authenticationStateProvider.GetAuthenticationStateAsync();
+        if (authenticationState.User.Identity?.IsAuthenticated != true)
+        {
+            throw new OpenLoopsApiException(
+                "authentication-required",
+                "Sign in again to continue.");
+        }
+
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            CircuitDelegation.AuthorizationScheme,
+            tokenService.Issue(
+                authenticationState.User,
+                CircuitDelegation.OpenLoopsAudience));
+        if (!string.IsNullOrWhiteSpace(antiforgeryCookie))
+        {
+            request.Headers.TryAddWithoutValidation("Cookie", antiforgeryCookie);
+        }
+
+        var response = await httpClient.SendAsync(request, cancellationToken);
+        if (response.Headers.TryGetValues("Set-Cookie", out var values))
+        {
+            var cookie = values
+                .Select(value => value.Split(';', 2)[0])
+                .LastOrDefault(value =>
+                    value.StartsWith(".AspNetCore.Antiforgery.", StringComparison.Ordinal));
+            if (cookie is not null)
+            {
+                antiforgeryCookie = cookie;
+            }
+        }
+
+        return response;
+    }
+
+    private static async Task EnsureSuccessAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        ApiErrorDto? error = null;
+        try
+        {
+            error = await response.Content.ReadFromJsonAsync<ApiErrorDto>(
+                cancellationToken: cancellationToken);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+        }
+
+        throw new OpenLoopsApiException(
+            error?.Code ?? $"http-{(int)response.StatusCode}",
+            error?.Message ?? "The request could not be completed.");
+    }
+
     private async Task<string> GetAntiforgeryTokenAsync(CancellationToken cancellationToken)
     {
-        var response = await httpClient.GetFromJsonAsync<AntiforgeryTokenDto>(
+        var response = await GetAsync<AntiforgeryTokenDto>(
             OpenLoopsApi.AntiforgeryRoute,
             cancellationToken);
         return response?.Token

--- a/src/Andreja.AppHost/OpenLoops/OpenLoopsServiceCollectionExtensions.cs
+++ b/src/Andreja.AppHost/OpenLoops/OpenLoopsServiceCollectionExtensions.cs
@@ -144,7 +144,6 @@ public static class OpenLoopsServiceCollectionExtensions
                 : OpenLoopsSkill.CreateDeterministicProvider());
         services.AddScoped<OpenLoopsAssistantService>();
 
-        services.AddTransient<CircuitDelegationHandler>();
         services.AddHttpClient<IOpenLoopsApiClient, OpenLoopsApiClient>(
                 (provider, client) =>
                 {
@@ -153,8 +152,7 @@ public static class OpenLoopsServiceCollectionExtensions
                     client.Timeout = TimeSpan.FromSeconds(30);
                 })
             .ConfigurePrimaryHttpMessageHandler(
-                () => CreateSameOriginHandler(environment))
-            .AddHttpMessageHandler<CircuitDelegationHandler>();
+                () => CreateSameOriginHandler(environment));
         return services;
     }
 

--- a/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
+++ b/tests/Andreja.ArchitectureTests/DependencyDirectionTests.cs
@@ -115,19 +115,32 @@ public sealed class DependencyDirectionTests
     }
 
     [Fact]
-    public void InteractiveTypedClientDoesNotDependOnHttpContextOrCookieForwarding()
+    public void PooledHttpHandlersDoNotCaptureCircuitOrRequestState()
     {
-        var constructorDependencies = typeof(CircuitDelegationHandler)
+        var clientDependencies = typeof(OpenLoopsApiClient)
             .GetConstructors()
             .SelectMany(constructor => constructor.GetParameters())
             .Select(parameter => parameter.ParameterType)
             .ToArray();
+        var statefulHandlers = typeof(OpenLoopsApiClient).Assembly.GetTypes()
+            .Where(type => type.IsAssignableTo(typeof(DelegatingHandler)))
+            .Where(type => type.GetConstructors()
+                .SelectMany(constructor => constructor.GetParameters())
+                .Any(parameter =>
+                    parameter.ParameterType.FullName
+                        == "Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider"
+                    || parameter.ParameterType.FullName
+                        == "Microsoft.AspNetCore.Http.IHttpContextAccessor"))
+            .ToArray();
 
+        Assert.Contains(
+            clientDependencies,
+            type => type.FullName
+                == "Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider");
+        Assert.Contains(typeof(ICircuitDelegationTokenService), clientDependencies);
+        Assert.Empty(statefulHandlers);
         Assert.DoesNotContain(
-            constructorDependencies,
-            type => type.FullName == "Microsoft.AspNetCore.Http.IHttpContextAccessor");
-        Assert.DoesNotContain(
-            typeof(CircuitDelegationHandler).Assembly.GetTypes(),
+            typeof(OpenLoopsApiClient).Assembly.GetTypes(),
             type => type.Name.Contains(
                 "CookieForwarding",
                 StringComparison.OrdinalIgnoreCase));

--- a/tests/Andreja.UnitTests/OpenLoopsApiIntegrationTests.cs
+++ b/tests/Andreja.UnitTests/OpenLoopsApiIntegrationTests.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
 using System.Net;
 using System.Net.Http.Json;
@@ -196,37 +198,70 @@ public sealed class OpenLoopsApiIntegrationTests : IClassFixture<OpenLoopsWebApp
 #endif
 
     [Fact]
-    public async Task CircuitDelegationUsesRealTypedClientWithoutHttpContext()
+    public async Task ActualDiTypedClientsKeepConcurrentCircuitIdentitiesIsolated()
     {
         Assert.Null(new HttpContextAccessor().HttpContext);
-        using var client = factory.CreateCircuitApiClient();
+        var handlerBuildsBefore = factory.HandlerBuildCount;
+        using var first = factory.CreateCircuitApiClient(
+            Guid.Parse("0198D117-3D00-7000-8000-00000000C101"),
+            Guid.Parse("0198D117-3D00-7000-8000-00000000C102"),
+            Guid.Parse("0198D117-3D00-7000-8000-00000000C103"));
+        using var second = factory.CreateCircuitApiClient(
+            Guid.Parse("0198D117-3D00-7000-8000-00000000C201"),
+            Guid.Parse("0198D117-3D00-7000-8000-00000000C202"),
+            Guid.Parse("0198D117-3D00-7000-8000-00000000C203"));
 
-        var provider = await client.Api.GetProviderAsync();
-        Assert.True(provider.Ready);
-        Assert.Empty(await client.Api.ListAsync());
+        var proposals = await Task.WhenAll(
+            first.Api.ProposeAsync("First circuit task"),
+            second.Api.ProposeAsync("Second circuit task"));
+        var firstProposal = Assert.IsType<TaskProposalDto>(proposals[0].Proposal);
+        var secondProposal = Assert.IsType<TaskProposalDto>(proposals[1].Proposal);
+        var confirmations = await Task.WhenAll(
+            first.Api.ConfirmAsync(
+                firstProposal.Id,
+                firstProposal.Version,
+                "circuit-first-confirm"),
+            second.Api.ConfirmAsync(
+                secondProposal.Id,
+                secondProposal.Version,
+                "circuit-second-confirm"));
+        var firstTask = Assert.IsType<TaskDto>(confirmations[0].Task);
+        var secondTask = Assert.IsType<TaskDto>(confirmations[1].Task);
 
-        var proposed = await client.Api.ProposeAsync("Circuit delegated task");
-        var proposal = Assert.IsType<TaskProposalDto>(proposed.Proposal);
-        var confirmed = await client.Api.ConfirmAsync(
-            proposal.Id,
-            proposal.Version,
-            "circuit-confirm-0001");
-        var task = Assert.IsType<TaskDto>(confirmed.Task);
-        var completed = await client.Api.CompleteAsync(
-            task.Id,
-            task.Version,
-            "circuit-complete-0001");
-        Assert.Equal(TaskStatusDto.Completed, completed.Task?.Status);
-        Assert.Equal(
-            TaskStatusDto.Completed,
-            Assert.Single((await client.Api.ExportAsync()).Tasks).Status);
-        var deleted = await client.Api.DeleteAsync(
-            task.Id,
-            completed.Task!.Version,
-            "circuit-delete-0001");
+        var lists = await Task.WhenAll(
+            first.Api.ListAsync(),
+            second.Api.ListAsync());
+        Assert.Equal("First circuit task", Assert.Single(lists[0]).Title);
+        Assert.Equal("Second circuit task", Assert.Single(lists[1]).Title);
+        Assert.Equal(handlerBuildsBefore + 1, factory.HandlerBuildCount);
 
-        Assert.Equal("Applied", deleted.Outcome);
-        Assert.Empty(await client.Api.ListAsync());
+        var completions = await Task.WhenAll(
+            first.Api.CompleteAsync(
+                firstTask.Id,
+                firstTask.Version,
+                "circuit-first-complete"),
+            second.Api.CompleteAsync(
+                secondTask.Id,
+                secondTask.Version,
+                "circuit-second-complete"));
+        Assert.All(
+            completions,
+            completion => Assert.Equal(TaskStatusDto.Completed, completion.Task?.Status));
+        var exports = await Task.WhenAll(
+            first.Api.ExportAsync(),
+            second.Api.ExportAsync());
+        Assert.Equal("First circuit task", Assert.Single(exports[0].Tasks).Title);
+        Assert.Equal("Second circuit task", Assert.Single(exports[1].Tasks).Title);
+
+        await Task.WhenAll(
+            first.Api.DeleteAsync(
+                firstTask.Id,
+                completions[0].Task!.Version,
+                "circuit-first-delete"),
+            second.Api.DeleteAsync(
+                secondTask.Id,
+                completions[1].Task!.Version,
+                "circuit-second-delete"));
     }
 
     [Fact]
@@ -368,32 +403,46 @@ public sealed class OpenLoopsApiIntegrationTests : IClassFixture<OpenLoopsWebApp
 
 public sealed class OpenLoopsWebApplicationFactory : WebApplicationFactory<Program>
 {
+    private int handlerBuildCount;
+
+    public int HandlerBuildCount => Volatile.Read(ref handlerBuildCount);
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Development");
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<AuthenticationStateProvider>();
+            services.AddScoped<CircuitTestIdentity>();
+            services.AddScoped<AuthenticationStateProvider, ScopedAuthenticationStateProvider>();
+            services.ConfigureAll<HttpClientFactoryOptions>(
+                options => options.HttpMessageHandlerBuilderActions.Add(httpBuilder =>
+                {
+                    Interlocked.Increment(ref handlerBuildCount);
+                    httpBuilder.PrimaryHandler = Server.CreateHandler();
+                }));
+        });
     }
 
-    public CircuitClient CreateCircuitApiClient()
+    public CircuitClient CreateCircuitApiClient(
+        Guid tenantId,
+        Guid appUserId,
+        Guid principalId)
     {
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(
+        _ = Server;
+        var scope = Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<CircuitTestIdentity>().Principal =
+            new ClaimsPrincipal(new ClaimsIdentity(
             [
-                new(ClaimTypes.NameIdentifier, TestAppUserId.ToString("D")),
-                new(AndrejaClaimTypes.TenantId, TestTenantId.ToString("D")),
-                new(AndrejaClaimTypes.AppUserId, TestAppUserId.ToString("D")),
-                new(AndrejaClaimTypes.PrincipalId, TestPrincipalId.ToString("D")),
+                new(ClaimTypes.NameIdentifier, appUserId.ToString("D")),
+                new(AndrejaClaimTypes.TenantId, tenantId.ToString("D")),
+                new(AndrejaClaimTypes.AppUserId, appUserId.ToString("D")),
+                new(AndrejaClaimTypes.PrincipalId, principalId.ToString("D")),
             ],
             "circuit-test"));
-        var delegation = new CircuitDelegationHandler(
-            new FixedAuthenticationStateProvider(principal),
-            Services.GetRequiredService<ICircuitDelegationTokenService>())
-        {
-            InnerHandler = Server.CreateHandler(),
-        };
-        var httpClient = new HttpClient(delegation)
-        {
-            BaseAddress = new Uri("https://localhost"),
-        };
-        return new(new OpenLoopsApiClient(httpClient), httpClient);
+        return new(
+            scope.ServiceProvider.GetRequiredService<IOpenLoopsApiClient>(),
+            scope);
     }
 
     public HttpClient CreateAnonymousClient() =>
@@ -427,18 +476,16 @@ public sealed class OpenLoopsWebApplicationFactory : WebApplicationFactory<Progr
         return client;
     }
 
-    private static readonly Guid TestTenantId =
-        Guid.Parse("0198D117-3D00-7000-8000-00000000C001");
-    private static readonly Guid TestAppUserId =
-        Guid.Parse("0198D117-3D00-7000-8000-00000000C002");
-    private static readonly Guid TestPrincipalId =
-        Guid.Parse("0198D117-3D00-7000-8000-00000000C003");
+    private sealed class CircuitTestIdentity
+    {
+        public ClaimsPrincipal Principal { get; set; } = new(new ClaimsIdentity());
+    }
 
-    private sealed class FixedAuthenticationStateProvider(ClaimsPrincipal principal)
+    private sealed class ScopedAuthenticationStateProvider(CircuitTestIdentity identity)
         : AuthenticationStateProvider
     {
         public override Task<AuthenticationState> GetAuthenticationStateAsync() =>
-            Task.FromResult(new AuthenticationState(principal));
+            Task.FromResult(new AuthenticationState(identity.Principal));
     }
 
     public sealed class UnreachableOpenLoopsApiClient : IOpenLoopsApiClient
@@ -484,11 +531,11 @@ public sealed class OpenLoopsWebApplicationFactory : WebApplicationFactory<Progr
 
     public sealed class CircuitClient(
         IOpenLoopsApiClient api,
-        HttpClient httpClient) : IDisposable
+        IServiceScope scope) : IDisposable
     {
         public IOpenLoopsApiClient Api { get; } = api;
 
-        public void Dispose() => httpClient.Dispose();
+        public void Dispose() => scope.Dispose();
     }
 }
 

--- a/tests/Andreja.UnitTests/OpenLoopsVerticalSliceTests.cs
+++ b/tests/Andreja.UnitTests/OpenLoopsVerticalSliceTests.cs
@@ -273,16 +273,13 @@ public sealed class OpenLoopsVerticalSliceTests
             new EphemeralDataProtectionProvider(),
             new MutableTimeProvider(Now));
         var handler = new RecordingHandler();
-        var forwarding = new CircuitDelegationHandler(
+        var client = new OpenLoopsApiClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://andreja.test"),
+            },
             new FixedAuthenticationStateProvider(principal),
-            tokenService)
-        {
-            InnerHandler = handler,
-        };
-        var client = new OpenLoopsApiClient(new HttpClient(forwarding)
-        {
-            BaseAddress = new Uri("https://andreja.test"),
-        });
+            tokenService);
 
         var result = await client.ProposeAsync("Call the dentist");
 


### PR DESCRIPTION
## Why

Critical lifetime follow-up to merged #57.

A pooled `DelegatingHandler` cannot depend on Blazor's circuit-scoped `AuthenticationStateProvider`. This fix resolves authentication state in transient `OpenLoopsApiClient`, mints a fresh one-use token per call, and keeps the `IHttpClientFactory` pipeline stateless.

## Approach

- Remove the stateful delegation handler.
- Resolve circuit `AuthenticationStateProvider` in the typed-client call site.
- Attach a fresh audience-bound, short-lived, one-use Data Protection token per request.
- Keep antiforgery state on the circuit's typed-client instance.
- Preserve dedicated internal-token authentication and external cookie/passkey API authentication.

## Regression evidence

- Two concurrent DI scopes resolve `IOpenLoopsApiClient` through the production `AddHttpClient` registration with different principals/tenants.
- Both scopes share one pooled primary handler yet see only their own tasks and exports.
- The real TestServer API and antiforgery filter run with null `HttpContext`.
- Architecture tests reject pooled handlers that capture `AuthenticationStateProvider` or `IHttpContextAccessor`.
- Expiry, replay, audience, tamper, claim, and external cookie/API negatives remain covered.

## Final operations sync

- Exact parent: `793d4116377174e813ff5c595f709c4691f6ee01`.
- Old remote lease: `eafae45244bc5e233ff3fb25420556f988488132`.
- Rebased head: `490cf0cb12e85536cdedd76f4fbd2598a3728e1f`.
- Rebase conflicts: none.
- Explicit `--force-with-lease` succeeded.
- Diff remains one isolated commit.

## Validation after rebase

- Debug build: passed, 0 warnings/errors
- Debug tests: 112 passed (99 unit/API/DI-circuit + 13 architecture)
- Release build: passed, 0 warnings/errors
- Release tests: 110 passed (97 unit/API/DI-circuit + 13 architecture)
- Targeted concurrent two-scope DI and token negatives: 4 passed in Debug and 4 passed in Release
- PostgreSQL integration project build: passed
- Format, docs consistency, operations contract, shell syntax, vulnerability scan, and diff check: passed
- Live HTTPS smoke: login 200, local sign-in 302 redirect, authenticated API 200, anonymous API 401 JSON/no redirect
- Hosted Docs Consistency: passed
- GitHub merge state: CLEAN

## Gates

- [x] Rebased onto exact live operations parent
- [x] Circuit-scoped identity resolved at typed-client call site
- [x] Pooled pipeline stateless
- [x] Concurrent two-scope tenant/principal isolation automated
- [x] Debug and Release suites passed
- [x] Hosted checks passed; merge state clean
- [x] Ready for independent review
- [ ] Production passkey blocker #55 completed before Phase 1A exit

## Stack

Base: `squad/40-phase1a-operations` at `793d411`. PR contains only the scoped circuit-client lifetime fix.
