### PR TITLE
Consolidate redundant workflow triggers

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -24,8 +24,6 @@ jobs:
   build:
     permissions:
       contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # required for private repositories by github/codeql-action/upload-sarif
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
@@ -67,8 +65,3 @@ jobs:
           name: psscriptanalyzer-results
           path: results.sarif
           if-no-files-found: error
-
-      - name: Upload SARIF results to code scanning
-        uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
-        with:
-          sarif_file: results.sarif

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -24,6 +24,8 @@ jobs:
   build:
     permissions:
       contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # required for private repositories by github/codeql-action/upload-sarif
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
@@ -65,3 +67,8 @@ jobs:
           name: psscriptanalyzer-results
           path: results.sarif
           if-no-files-found: error
+
+      - name: Upload SARIF results to code scanning
+        uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -7,9 +7,9 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  # React to completed work or new squad work
+  # React to completed work
   issues:
-    types: [closed, labeled]
+    types: [closed]
   pull_request:
     types: [closed]
 

--- a/.squad/templates/workflows/squad-heartbeat.yml
+++ b/.squad/templates/workflows/squad-heartbeat.yml
@@ -7,9 +7,9 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  # React to completed work or new squad work
+  # React to completed work
   issues:
-    types: [closed, labeled]
+    types: [closed]
   pull_request:
     types: [closed]
 


### PR DESCRIPTION
## Why

Squad Heartbeat and Squad Triage both reacted to issue label events, creating redundant automation and a risk of duplicate routing. This change leaves label-based routing with Triage while preserving Heartbeat's distinct board-rescan responsibilities.

No linked issue.

## Approach

Remove the `labeled` issue trigger from the active Heartbeat workflow and its installed template. Heartbeat still runs for closed issues, closed pull requests, and manual dispatch, while Squad Triage remains responsible for new `squad` labels.

The broader live workflow cleanup also disabled the stale Squad CI entry and duplicate CodeQL Advanced workflow. GitHub's organization-managed Code Quality workflow remains the sole active CodeQL path.

## Charter impact

Improves operational sustainability and evidence quality by avoiding duplicate workflow execution and conflicting routing. No user data, AI behavior, product ownership, or stakeholder incentives change. The automation can be restored by re-adding the trigger if needed.

## Validation

- `python -c "import glob,yaml; files=glob.glob('.github/workflows/*.yml')+glob.glob('.squad/templates/workflows/*.yml'); [yaml.safe_load(open(f,encoding='utf-8')) for f in files]; print(f'Parsed {len(files)} workflow YAML files')"` - parsed 19 files.
- `git diff --check origin/main...HEAD` - passed.
- PowerShell assertion checking both Heartbeat files for `issues.types` containing `labeled` - passed.
- Independent Data review - approved after workflow security compatibility corrections.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A. This PR targets `main` directly.