### PR TITLE
Add hosted .NET 10 validation gates

### DIFF
--- a/.github/scripts/invoke-nuget-vulnerability-scan.ps1
+++ b/.github/scripts/invoke-nuget-vulnerability-scan.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+param(
+    [string] $OutputPath = 'artifacts/vulnerability/nuget-vulnerabilities.json'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$targets = [ordered]@{
+    solution = 'Andreja.slnx'
+    postgresql_integration_project = 'tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj'
+}
+
+$scans = [ordered]@{}
+foreach ($target in $targets.GetEnumerator()) {
+    $output = & dotnet list $target.Value package --vulnerable --include-transitive --format json --output-version 1
+    if ($LASTEXITCODE -ne 0) {
+        throw "NuGet vulnerability scan failed for $($target.Value) with exit code $LASTEXITCODE."
+    }
+
+    $scans[$target.Key] = ($output -join [Environment]::NewLine) | ConvertFrom-Json
+}
+
+$findings = @(
+    foreach ($scan in $scans.Values) {
+        foreach ($project in @($scan.projects)) {
+            foreach ($framework in @($project.frameworks)) {
+                foreach ($packageType in @('topLevelPackages', 'transitivePackages')) {
+                    foreach ($package in @($framework.$packageType)) {
+                        foreach ($vulnerability in @($package.vulnerabilities)) {
+                            if ($null -ne $vulnerability) {
+                                [ordered]@{
+                                    project = $project.path
+                                    framework = $framework.framework
+                                    package_type = $packageType
+                                    package = $package.id
+                                    resolved_version = $package.resolvedVersion
+                                    severity = $vulnerability.severity
+                                    advisory_url = $vulnerability.advisoryurl
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+)
+
+$report = [ordered]@{
+    schema_version = 1
+    generated_utc = [DateTimeOffset]::UtcNow.ToString('O')
+    direct_and_transitive = $true
+    finding_count = $findings.Count
+    findings = $findings
+    scans = $scans
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+if ($outputDirectory) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+$report | ConvertTo-Json -Depth 20 | Set-Content -Path $OutputPath -Encoding utf8
+
+if ($findings.Count -gt 0) {
+    throw "NuGet reported $($findings.Count) direct or transitive vulnerable package finding(s)."
+}

--- a/.github/scripts/write-dotnet-validation-report.ps1
+++ b/.github/scripts/write-dotnet-validation-report.ps1
@@ -1,0 +1,164 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('build-test', 'format', 'vulnerability', 'sast')]
+    [string] $Kind,
+
+    [Parameter(Mandatory)]
+    [string] $OutputPath,
+
+    [Parameter(Mandatory)]
+    [string] $ResultsJson,
+
+    [string] $Configuration = 'N/A',
+
+    [string] $RepositoryRoot = (Get-Location).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$expectedTestProjects = @(
+    'tests/Andreja.ArchitectureTests/Andreja.ArchitectureTests.csproj'
+    'tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj'
+    'tests/Andreja.UnitTests/Andreja.UnitTests.csproj'
+)
+
+$discoveredTestProjects = @(
+    Get-ChildItem -Path (Join-Path $RepositoryRoot 'tests') -Filter '*.csproj' -Recurse |
+        ForEach-Object {
+            [IO.Path]::GetRelativePath($RepositoryRoot, $_.FullName).Replace('\', '/')
+        } |
+        Sort-Object
+)
+
+$inventoryDifference = @(
+    Compare-Object -ReferenceObject $expectedTestProjects -DifferenceObject $discoveredTestProjects
+)
+
+if ($inventoryDifference.Count -gt 0) {
+    $difference = $inventoryDifference | ForEach-Object { "$($_.SideIndicator) $($_.InputObject)" }
+    throw "Test-project inventory changed. Classify every project before publishing evidence:`n$($difference -join "`n")"
+}
+
+$results = $ResultsJson | ConvertFrom-Json -AsHashtable
+$sdkVersion = (Get-Content (Join-Path $RepositoryRoot 'global.json') -Raw | ConvertFrom-Json).sdk.version
+$postgresProject = 'tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj'
+
+$commands = switch ($Kind) {
+    'build-test' {
+        @(
+            "dotnet restore Andreja.slnx"
+            "dotnet restore $postgresProject"
+            "dotnet build Andreja.slnx --configuration $Configuration --no-restore"
+            "dotnet build $postgresProject --configuration $Configuration --no-restore"
+            "dotnet test Andreja.slnx --configuration $Configuration --no-build"
+        )
+    }
+    'format' {
+        @(
+            'dotnet restore Andreja.slnx'
+            "dotnet restore $postgresProject"
+            'dotnet format Andreja.slnx --verify-no-changes --no-restore'
+            "dotnet format $postgresProject --verify-no-changes --no-restore"
+        )
+    }
+    'vulnerability' {
+        @(
+            'dotnet restore Andreja.slnx'
+            "dotnet restore $postgresProject"
+            'dotnet list Andreja.slnx package --vulnerable --include-transitive --format json --output-version 1'
+            "dotnet list $postgresProject package --vulnerable --include-transitive --format json --output-version 1"
+        )
+    }
+    'sast' {
+        @(
+            'dotnet tool install Microsoft.CST.DevSkim.CLI --version 1.0.90'
+            'devskim analyze --source-code . --include-globs **/*.cs --ignore-rule-ids DS137138,DS162092 --output-file devskim-results.sarif'
+        )
+    }
+}
+
+$report = [ordered]@{
+    schema_version = 1
+    generated_utc = [DateTimeOffset]::UtcNow.ToString('O')
+    validation = [ordered]@{
+        kind = $Kind
+        configuration = $Configuration
+        sdk_version = $sdkVersion
+        runner_image = 'ubuntu-24.04'
+        workflow = $env:GITHUB_WORKFLOW
+        run_id = $env:GITHUB_RUN_ID
+        run_attempt = $env:GITHUB_RUN_ATTEMPT
+        commit_sha = $env:GITHUB_SHA
+        commands = $commands
+        results = $results
+    }
+    test_projects = [ordered]@{
+        included = @(
+            [ordered]@{
+                path = 'tests/Andreja.ArchitectureTests/Andreja.ArchitectureTests.csproj'
+                classification = 'service-free runtime test'
+                runtime_result = if ($Kind -eq 'build-test') { $results.test_solution } else { 'not-run-in-this-job' }
+            }
+            [ordered]@{
+                path = 'tests/Andreja.UnitTests/Andreja.UnitTests.csproj'
+                classification = 'service-free runtime test'
+                runtime_result = if ($Kind -eq 'build-test') { $results.test_solution } else { 'not-run-in-this-job' }
+            }
+        )
+        excluded = @(
+            [ordered]@{
+                path = $postgresProject
+                excluded_from = 'Andreja.slnx runtime tests'
+                reason = 'Requires a disposable PostgreSQL database and is intentionally outside the service-free solution.'
+                compile_result = if ($Kind -eq 'build-test') { $results.build_postgresql } else { 'not-run-in-this-job' }
+            }
+        )
+        unavailable = @(
+            [ordered]@{
+                path = $postgresProject
+                runtime_result = 'unavailable'
+                reason = 'Hosted validation does not receive a database credential or provision PostgreSQL; invoking the project without one fails BLOCKED rather than skipping.'
+                runtime_command = "dotnet test $postgresProject --configuration $Configuration"
+            }
+        )
+    }
+    boundaries = [ordered]@{
+        untrusted_pull_requests = 'No secrets or write-capable token; checkout credentials are not persisted.'
+        codeql_entitlement = 'Unavailable: private-repository Code Security is disabled and the CodeQL configuration endpoint returns HTTP 403.'
+        devskim_baseline = 'DS137138 excludes intentional loopback HTTP test/development URLs; DS162092 excludes false positives on explicit Debug/Development safeguards.'
+        ruleset_enforcement = 'Tracked separately in GitHub issue #67.'
+        sbom_and_provenance = 'Tracked separately in GitHub issue #71.'
+    }
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+if ($outputDirectory) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+$report | ConvertTo-Json -Depth 12 | Set-Content -Path $OutputPath -Encoding utf8
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    $operationRows = @(
+        foreach ($entry in $results.GetEnumerator()) {
+            "| $($entry.Key) | $($entry.Value) |"
+        }
+    )
+
+    @"
+## $Kind validation evidence ($Configuration)
+
+| Operation | Result |
+| --- | --- |
+$($operationRows -join "`n")
+
+### Test-project inventory
+
+| Classification | Project | Runtime evidence |
+| --- | --- | --- |
+| Included | tests/Andreja.ArchitectureTests/Andreja.ArchitectureTests.csproj | $(if ($Kind -eq 'build-test') { $results.test_solution } else { 'not run in this job' }) |
+| Included | tests/Andreja.UnitTests/Andreja.UnitTests.csproj | $(if ($Kind -eq 'build-test') { $results.test_solution } else { 'not run in this job' }) |
+| Excluded from solution runtime | $postgresProject | compiled separately in Debug and Release |
+| Unavailable runtime | $postgresProject | no disposable hosted PostgreSQL; never reported as passed or skipped |
+"@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8
+}

--- a/.github/workflows/dotnet-validation.yml
+++ b/.github/workflows/dotnet-validation.yml
@@ -1,0 +1,277 @@
+name: .NET Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dotnet-validation-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+  DOTNET_NOLOGO: '1'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
+
+jobs:
+  build-test:
+    name: Build and test (${{ matrix.configuration }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Release]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pinned .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - name: Record SDK
+        run: dotnet --info
+
+      - id: restore_solution
+        name: Restore service-free solution
+        run: dotnet restore Andreja.slnx
+
+      - id: restore_postgresql
+        name: Restore PostgreSQL integration project
+        run: dotnet restore tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj
+
+      - id: build_solution
+        name: Build service-free solution
+        run: dotnet build Andreja.slnx --configuration ${{ matrix.configuration }} --no-restore
+
+      - id: build_postgresql
+        name: Compile PostgreSQL integration project
+        run: dotnet build tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj --configuration ${{ matrix.configuration }} --no-restore
+
+      - id: test_solution
+        name: Test service-free solution
+        run: >-
+          dotnet test Andreja.slnx
+          --configuration ${{ matrix.configuration }}
+          --no-build
+          --logger "trx;LogFilePrefix=${{ matrix.configuration }}"
+          --results-directory artifacts/${{ matrix.configuration }}/test-results
+
+      - id: report
+        if: always()
+        name: Write complete test-project evidence
+        shell: pwsh
+        env:
+          VALIDATION_RESULTS: >-
+            {"restore_solution":"${{ steps.restore_solution.outcome }}",
+            "restore_postgresql":"${{ steps.restore_postgresql.outcome }}",
+            "build_solution":"${{ steps.build_solution.outcome }}",
+            "build_postgresql":"${{ steps.build_postgresql.outcome }}",
+            "test_solution":"${{ steps.test_solution.outcome }}"}
+        run: >-
+          ./.github/scripts/write-dotnet-validation-report.ps1
+          -Kind build-test
+          -Configuration '${{ matrix.configuration }}'
+          -ResultsJson $env:VALIDATION_RESULTS
+          -OutputPath 'artifacts/${{ matrix.configuration }}/validation-report.json'
+
+      - if: always() && steps.report.outcome == 'success'
+        name: Upload bounded validation evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dotnet-${{ matrix.configuration }}-evidence-${{ github.run_attempt }}
+          path: artifacts/${{ matrix.configuration }}
+          if-no-files-found: error
+          retention-days: 14
+
+  format:
+    name: Format verification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pinned .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - id: restore_solution
+        name: Restore service-free solution
+        run: dotnet restore Andreja.slnx
+
+      - id: restore_postgresql
+        name: Restore PostgreSQL integration project
+        run: dotnet restore tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj
+
+      - id: format_solution
+        name: Verify solution formatting
+        run: dotnet format Andreja.slnx --verify-no-changes --no-restore
+
+      - id: format_postgresql
+        name: Verify PostgreSQL integration project formatting
+        run: dotnet format tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj --verify-no-changes --no-restore
+
+      - id: report
+        if: always()
+        name: Write complete test-project evidence
+        shell: pwsh
+        env:
+          VALIDATION_RESULTS: >-
+            {"restore_solution":"${{ steps.restore_solution.outcome }}",
+            "restore_postgresql":"${{ steps.restore_postgresql.outcome }}",
+            "format_solution":"${{ steps.format_solution.outcome }}",
+            "format_postgresql":"${{ steps.format_postgresql.outcome }}"}
+        run: >-
+          ./.github/scripts/write-dotnet-validation-report.ps1
+          -Kind format
+          -ResultsJson $env:VALIDATION_RESULTS
+          -OutputPath artifacts/format/validation-report.json
+
+      - if: always() && steps.report.outcome == 'success'
+        name: Upload bounded format evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dotnet-format-evidence-${{ github.run_attempt }}
+          path: artifacts/format
+          if-no-files-found: error
+          retention-days: 14
+
+  vulnerability:
+    name: NuGet vulnerability audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pinned .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - id: restore_solution
+        name: Restore service-free solution
+        run: dotnet restore Andreja.slnx
+
+      - id: restore_postgresql
+        name: Restore PostgreSQL integration project
+        run: dotnet restore tests/Andreja.PostgreSqlIntegrationTests/Andreja.PostgreSqlIntegrationTests.csproj
+
+      - id: audit
+        name: Report direct and transitive vulnerabilities
+        shell: pwsh
+        run: ./.github/scripts/invoke-nuget-vulnerability-scan.ps1
+
+      - id: report
+        if: always()
+        name: Write complete test-project evidence
+        shell: pwsh
+        env:
+          VALIDATION_RESULTS: >-
+            {"restore_solution":"${{ steps.restore_solution.outcome }}",
+            "restore_postgresql":"${{ steps.restore_postgresql.outcome }}",
+            "direct_transitive_audit":"${{ steps.audit.outcome }}"}
+        run: >-
+          ./.github/scripts/write-dotnet-validation-report.ps1
+          -Kind vulnerability
+          -ResultsJson $env:VALIDATION_RESULTS
+          -OutputPath artifacts/vulnerability/validation-report.json
+
+      - if: always() && steps.report.outcome == 'success'
+        name: Upload bounded vulnerability evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nuget-vulnerability-evidence-${{ github.run_attempt }}
+          path: artifacts/vulnerability
+          if-no-files-found: error
+          retention-days: 14
+
+  sast:
+    name: C# SAST (DevSkim)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pinned .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          global-json-file: global.json
+
+      - id: install
+        name: Install pinned Microsoft DevSkim
+        run: dotnet tool install Microsoft.CST.DevSkim.CLI --version 1.0.90 --tool-path .tools/devskim
+
+      - id: analyze
+        name: Analyze C# source without uploading source
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path artifacts/sast -Force | Out-Null
+          & ./.tools/devskim/devskim analyze `
+            --source-code . `
+            --output-file artifacts/sast/devskim-results.sarif `
+            --include-globs '**/*.cs' `
+            --ignore-globs '**/.git/**,**/bin/**,**/obj/**,**/artifacts/**,**/.tools/**' `
+            --ignore-rule-ids 'DS137138,DS162092'
+          if ($LASTEXITCODE -ne 0) {
+            throw "DevSkim analysis failed with exit code $LASTEXITCODE."
+          }
+
+      - id: findings
+        name: Fail on DevSkim findings
+        shell: pwsh
+        run: |
+          $sarif = Get-Content artifacts/sast/devskim-results.sarif -Raw | ConvertFrom-Json
+          $findings = @($sarif.runs | ForEach-Object { @($_.results) })
+          if ($findings.Count -gt 0) {
+            foreach ($finding in $findings) {
+              Write-Host "::error::$($finding.message.text)"
+            }
+            throw "DevSkim reported $($findings.Count) finding(s)."
+          }
+
+      - id: report
+        if: always()
+        name: Write complete test-project evidence
+        shell: pwsh
+        env:
+          VALIDATION_RESULTS: >-
+            {"tool_install":"${{ steps.install.outcome }}",
+            "devskim_analysis":"${{ steps.analyze.outcome }}",
+            "finding_gate":"${{ steps.findings.outcome }}",
+            "baseline_exclusions":"DS137138-loopback-URLs;DS162092-Debug-guard-false-positives",
+            "codeql_entitlement":"unavailable-private-repository-code-security-disabled"}
+        run: >-
+          ./.github/scripts/write-dotnet-validation-report.ps1
+          -Kind sast
+          -ResultsJson $env:VALIDATION_RESULTS
+          -OutputPath artifacts/sast/validation-report.json
+
+      - if: always() && steps.report.outcome == 'success'
+        name: Upload bounded SAST evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: csharp-sast-evidence-${{ github.run_attempt }}
+          path: artifacts/sast
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/development.md
+++ b/docs/development.md
@@ -103,6 +103,13 @@ development and transport-boundary tests, while `DS162092` flags the words
 shipping in Release. Their exclusion is recorded in every SAST artifact.
 Re-evaluate both exclusions and CodeQL if the code or entitlement changes.
 
+GitHub may also attach a platform-managed dynamic `Analyze (csharp)` CodeQL
+check to a pull request. That supplementary check ran successfully while this
+gate was introduced, but it is not a repository-owned substitute: the committed
+CodeQL workflow remains manually disabled, the repository API still denies
+CodeQL configuration, and the dynamic check does not establish committed
+push-to-`main` or `merge_group` coverage.
+
 Default-branch required-check and merge-queue enforcement is deliberately
 tracked in [issue #67](https://github.com/Jamula/Andreja/issues/67). OCI SBOM,
 image scanning, and provenance remain in

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,9 +39,16 @@ Run these commands from the repository root:
 
 ```powershell
 dotnet restore Andreja.slnx
-dotnet build Andreja.slnx --no-restore
-dotnet test Andreja.slnx --no-build
+dotnet restore tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj
+dotnet build Andreja.slnx --configuration Debug --no-restore
+dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Debug --no-restore
+dotnet test Andreja.slnx --configuration Debug --no-build
+dotnet build Andreja.slnx --configuration Release --no-restore
+dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Release --no-restore
+dotnet test Andreja.slnx --configuration Release --no-build
 dotnet format Andreja.slnx --verify-no-changes --no-restore
+dotnet format tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --verify-no-changes --no-restore
+pwsh -NoProfile -File .github\scripts\invoke-nuget-vulnerability-scan.ps1
 pwsh -NoProfile -File scripts\operations\validate-contract.ps1
 bash -n scripts/operations/*.sh
 ```
@@ -61,6 +68,45 @@ part of the service-free solution test. Follow
 [`tests\Andreja.PostgreSqlIntegrationTests\README.md`](../tests/Andreja.PostgreSqlIntegrationTests/README.md).
 When PostgreSQL is unavailable, record this evidence as blocked; do not mark it
 skipped or successful.
+
+### Hosted .NET validation
+
+`.github\workflows\dotnet-validation.yml` runs on pull requests, pushes to
+`main`, and merge-queue groups. It uses the exact SDK in `global.json` on the
+explicit `ubuntu-24.04` runner, immutable action SHAs, read-only repository
+permissions, non-persisted checkout credentials, concurrency cancellation, and
+14-day evidence retention. Fork pull requests receive no secrets or
+write-capable token.
+
+Debug and Release each restore, build, and test the service-free solution, then
+compile `Andreja.PostgreSqlIntegrationTests` separately. The hosted workflow
+does not provision PostgreSQL or receive a database credential, so the database
+runtime evidence remains **unavailable**, never passed or skipped. Every job
+summary and machine-readable artifact enumerates:
+
+- **Included runtime projects:** `Andreja.ArchitectureTests` and
+  `Andreja.UnitTests`.
+- **Excluded from solution runtime but compiled:**
+  `Andreja.PostgreSqlIntegrationTests`.
+- **Unavailable runtime projects:** `Andreja.PostgreSqlIntegrationTests`, with
+  the missing disposable PostgreSQL dependency recorded.
+
+The private repository currently reports `code_security.status=disabled`, and
+the CodeQL configuration endpoint returns `403` with “Code Security must be
+enabled for this repository to use code scanning.” The existing disabled CodeQL
+workflow is therefore not presented as C# evidence. The hosted gate instead
+runs the pinned Microsoft DevSkim CLI `1.0.90` locally on the runner, uploads no
+source, and fails on remaining C# findings. Two noisy lexical rules are excluded
+explicitly: `DS137138` flags the intentional loopback HTTP URLs used by local
+development and transport-boundary tests, while `DS162092` flags the words
+`Debug` and `Development` in safeguards that prevent development behavior from
+shipping in Release. Their exclusion is recorded in every SAST artifact.
+Re-evaluate both exclusions and CodeQL if the code or entitlement changes.
+
+Default-branch required-check and merge-queue enforcement is deliberately
+tracked in [issue #67](https://github.com/Jamula/Andreja/issues/67). OCI SBOM,
+image scanning, and provenance remain in
+[issue #71](https://github.com/Jamula/Andreja/issues/71).
 
 ## Run the host
 

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -17,8 +17,10 @@ Never report unavailable live dependencies as passed.
 | Accessibility and responsive UI | Semantic headings/labels, live status/error regions, keyboard-native controls, reduced motion, mobile breakpoint, and safe interactive initialization failure | `dotnet test Andreja.slnx --no-build`; manual keyboard and 320/768/1280 px viewport review | Initialization failure automated; manual viewport evidence required before launch |
 | Browser E2E | Sign in, assistant proposal, confirm, complete, export, delete at mobile/tablet/desktop widths | Playwright | Blocked: the repository has no Playwright package or browser harness; no package was added solely for this slice |
 | Telemetry privacy | Task/proposal content attributes suppressed while route/status allowlist remains | `dotnet test Andreja.slnx --no-build` | Automated |
-| Formatting and docs | Compiler analyzers, format verification, contract and docs consistency | See `docs\development.md` | Required before PR readiness |
-| Vulnerabilities | Direct and transitive NuGet advisory scan | `dotnet list Andreja.slnx package --vulnerable --include-transitive` | Required before PR readiness |
+| Hosted .NET gate | Restore; Debug and Release solution build/test; separate Debug and Release PostgreSQL-project compile | `.github\workflows\dotnet-validation.yml` | Hosted on PR, push to `main`, and `merge_group`; artifacts enumerate included, excluded, and unavailable runtime projects |
+| Formatting and docs | Compiler analyzers, solution and PostgreSQL-project format verification, contract and docs consistency | See `docs\development.md` | Required before PR readiness |
+| Vulnerabilities | Direct and transitive NuGet advisory scan of the service-free solution and separately restored PostgreSQL project | `pwsh -NoProfile -File .github\scripts\invoke-nuget-vulnerability-scan.ps1` | Required locally and hosted before PR readiness |
+| C# SAST | Microsoft DevSkim CLI 1.0.90, pinned and executed locally on the hosted runner | `.github\workflows\dotnet-validation.yml` | CodeQL unavailable while private-repository Code Security is disabled; DevSkim fails on findings after the documented loopback-URL and Debug-guard lexical exclusions |
 
 The API integration fixture uses the real cookie scheme through the explicit
 Development-only sign-in endpoint for external API evidence. Its circuit regression


### PR DESCRIPTION
## Why

Closes #61

A green hosted check set did not prove the .NET 10 solution compiled or tested. This adds truthful hosted evidence while keeping ruleset enforcement in #67 and SBOM/provenance in #71.

Working as Jett Reno (Platform/SRE and Channel Platform Lead).

## Approach

- Run pinned-SDK Debug and Release restore/build/test on `ubuntu-24.04`.
- Compile `Andreja.PostgreSqlIntegrationTests` separately in both configurations; report its PostgreSQL runtime as unavailable, never passed/skipped.
- Verify format and direct/transitive NuGet vulnerabilities across the solution and separate integration project.
- Emit 14-day machine-readable artifacts and job summaries enumerating included, excluded, and unavailable test projects.
- Use pinned Microsoft DevSkim CLI 1.0.90 because private-repository Code Security is disabled and the CodeQL configuration endpoint returns HTTP 403.
- Run PR, push-to-main, and `merge_group` with read-only permissions, non-persisted credentials, no secrets, and concurrency cancellation.

## Charter impact

Improves truthful security/quality evidence without processing user data or provisioning cloud services. It uses included GitHub Actions capacity and a fixed runner/toolchain. Cyrus retains merge/ruleset authority. Stop conditions are any failed gate, inventory drift, vulnerable package, SAST finding, or changed CodeQL entitlement. No human-agency, accessibility, consent, or public-claim behavior changes.

## Validation

- `dotnet restore Andreja.slnx` — passed.
- `dotnet restore tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj` — passed.
- Debug `dotnet build` for solution and PostgreSQL project — passed, 0 warnings/errors.
- Debug `dotnet test Andreja.slnx --no-build` — 112 passed (13 architecture, 99 unit), 0 failed/skipped.
- Release `dotnet build` for solution and PostgreSQL project — passed, 0 warnings/errors.
- Release `dotnet test Andreja.slnx --no-build` — 110 passed (13 architecture, 97 unit), 0 failed/skipped.
- PostgreSQL runtime with no credential — failed `BLOCKED` as designed; runtime unavailable locally/hosted.
- `dotnet format` for solution and PostgreSQL project — passed.
- `pwsh -NoProfile -File .github\scripts\invoke-nuget-vulnerability-scan.ps1` — passed, 0 direct/transitive findings.
- Microsoft DevSkim CLI 1.0.90 C# scan — passed, 0 findings after documented DS137138/DS162092 lexical false-positive exclusions.
- `python .github/scripts/check_docs_consistency.py` — passed.
- YAML parse/security/action-pin validation — passed; 12 immutable action references, read-only token, no secrets/`pull_request_target`, bounded artifacts.
- New PowerShell script parse and applicable PSScriptAnalyzer rules — passed, 0 findings.

Test inventory in every hosted summary/artifact:
- Included runtime: `Andreja.ArchitectureTests`, `Andreja.UnitTests`.
- Excluded from solution runtime but compiled Debug/Release: `Andreja.PostgreSqlIntegrationTests`.
- Unavailable runtime: `Andreja.PostgreSqlIntegrationTests` (no disposable PostgreSQL database).

### Hosted evidence

- Final `.NET Validation` run [32701274553](https://github.com/Jamula/Andreja/actions/runs/32701274553): Debug build/test, Release build/test, format, vulnerability audit, and DevSkim all passed.
- Downloaded evidence verification: all five artifacts contained a machine-readable report with 2 included, 1 excluded, and 1 unavailable test-project entry.
- Docs Consistency and PSScriptAnalyzer passed.
- Platform-managed dynamic CodeQL run [32701272902](https://github.com/Jamula/Andreja/actions/runs/32701272902) passed `Analyze (csharp)`. It remains supplementary because the repository API reports Code Security disabled and the committed CodeQL workflow is manually disabled; it does not establish repository-owned push/`merge_group` coverage.

## Gates

- [x] Architecture/contract impact recorded: workflow/evidence only; no runtime contract change
- [x] Security/privacy/legal review recorded: least privilege and untrusted-PR boundaries above; no legal change
- [x] Cost/operability impact recorded: included Actions quota, 14-day retention, cancellation
- [x] Company charter impact recorded above
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes not applicable; developer/testing documentation updated
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A — independent PR targeting `main` at `892d127d3d6c990a6e5c54c9c52b063263e1694b`.