### PR TITLE
docs: track public website roadmap issues

### DIFF
--- a/docs/adr/0000-plan-ratification.md
+++ b/docs/adr/0000-plan-ratification.md
@@ -57,7 +57,7 @@ not match the merged `docs/plan.md`.
 
 - **Tracking issues:** [#94](https://github.com/Jamula/Andreja/issues/94) and
   [#93](https://github.com/Jamula/Andreja/issues/93)
-- **Pull request:** Pending
+- **Pull request:** [#95](https://github.com/Jamula/Andreja/pull/95)
 - **Plan SHA-256:** `69133d886866d97474073814572a95c16031995c0eb3bf297b793591ae924a3b`
 - **Approver:** Cyrus Jamula
 - **Decision:** Logged amendment; no architecture, phase, budget, publication, or

--- a/docs/adr/0000-plan-ratification.md
+++ b/docs/adr/0000-plan-ratification.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-08-23
 - **Approver:** Cyrus Jamula
 - **Plan:** [`docs/plan.md`](../plan.md)
-- **Plan SHA-256:** `9dfe3e8f81d140082270de0517ecc3f15d2a2090c5b6c530f83fe461ff8798c0`
+- **Plan SHA-256:** `69133d886866d97474073814572a95c16031995c0eb3bf297b793591ae924a3b`
 
 ## Decision
 
@@ -52,3 +52,15 @@ not match the merged `docs/plan.md`.
 - **Decision:** Logged amendment; no architecture or ratification change.
 - **Scope:** Update the canonical repository and organization Project references
   after transfer to `Jamula/Andreja`.
+
+### 2026-08-24 — public website execution tracking
+
+- **Tracking issues:** [#94](https://github.com/Jamula/Andreja/issues/94) and
+  [#93](https://github.com/Jamula/Andreja/issues/93)
+- **Pull request:** Pending
+- **Plan SHA-256:** `69133d886866d97474073814572a95c16031995c0eb3bf297b793591ae924a3b`
+- **Approver:** Cyrus Jamula
+- **Decision:** Logged amendment; no architecture, phase, budget, publication, or
+  ratification change.
+- **Scope:** Add explicit issue tracking for the private Phase 0 website
+  design/hosting matrix and the separately gated Phase 1B public/help site.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -931,6 +931,8 @@ Guinan is the User Feedback and Support Lead and owns acknowledgment, privacy sc
 
 ## Public website, help, and support
 
+- **Tracking:** Phase 0 design/hosting matrix [#94](https://github.com/Jamula/Andreja/issues/94);
+  gated Phase 1B public/help site [#93](https://github.com/Jamula/Andreja/issues/93).
 - Build a separate public-site project in this repository and .NET solution, deployed independently from the authenticated Andreja application and every user data plane.
 - Launch a minimal site with the walking skeleton covering the vision, capabilities, user data ownership, self-hosted and managed choices, privacy/security posture, roadmap boundaries, and honest availability status.
 - Expand the same site into the canonical help and support destination:
@@ -1333,7 +1335,7 @@ Deliverables:
 - Self-host identity qualification for HTTPS/WebAuthn RP configuration, first-admin bootstrap, recovery, external identity collision/linking, Data Protection key backup, and restoration.
 - OpenTofu state/provider design and local-backend validation with pinned providers/lock files, remote-state encryption/locking/recovery design, CI workload-identity design, deployment TTLs/quotas and teardown. Provisioning remote state and CI identity moves to separately budgeted Phase 1B.
 - Copilot event-schema and billing-reconciliation spike covering usage events, AI credits, session content persistence, provider retention, credential/tool isolation, and invoice-grade limits.
-- Jadzia-led public website design/hosting matrix with Jett Reno, Spock, and Quark; cover static/SSR options, help/search tooling, CDN/hosting, portability, security separation, preview environments, and cost.
+- Jadzia-led public website design/hosting matrix with Jett Reno, Spock, and Quark; cover static/SSR options, help/search tooling, CDN/hosting, portability, security separation, preview environments, and cost. Tracked by [#94](https://github.com/Jamula/Andreja/issues/94).
 - Initial threat model, privacy classification, numeric spike/steady-state cost envelopes, numeric SLO definitions with owners/evidence queries, and test strategy.
 - Evaluate but do not automatically install the recommended external skills/tools.
 
@@ -1373,7 +1375,7 @@ Deliverables:
 - After a separate budget approval, one capped Azure managed reference deployment using the Phase 0-selected relational provider—PostgreSQL is the provisional reference—through OpenTofu with pinned providers, locked/encrypted state, CI workload identity, quotas, TTL/teardown, secrets, backups, health, OTel export, and cost evidence.
 - Real limited Copilot 1.0.x provider. Use a shared runtime only after Phase 0/local and Phase 1B evidence proves filesystem/session/tool/credential/concurrency/cleanup/cost isolation; otherwise use per-user runtime isolation. Keep separate credentials/tools/session state, usage reconciliation and an optional external runtime image only if the measured topology requires it.
 - Invitees may link their own Copilot/BYOK provider or, only after Sarek's counsel/vendor-reviewed answer on Copilot entitlement, acceptable use and redistribution, opt into an Andreja-funded dogfood allowance. Funded usage has explicit consent, per-tenant quotas, model/tool limits, attribution, budget exhaustion behavior and no hidden transfer of one user's entitlement to another.
-- Independently deployed pre-generated public-site artifact, conditional on product-name/domain clearance, covering vision, data ownership, privacy posture, help/support and evidence-based availability.
+- Independently deployed pre-generated public-site artifact, conditional on product-name/domain clearance, covering vision, data ownership, privacy posture, help/support and evidence-based availability. Tracked by [#93](https://github.com/Jamula/Andreja/issues/93).
 - Tenant-less public feedback intake plus authenticated in-app feedback, Guinan triage/status workflow, and sanitized/consented GitHub issue publication.
 - Minimal transactional outbound email for Guinan acknowledgments/status, with sender identity, SPF/DKIM/DMARC, bounce/complaint handling, abuse controls and cost evidence. Phase 3A expands email intake, reminders and provider choice.
 - Invite-only adult onboarding for a small dogfood cohort, with each invitee in a separate tenant, repeatable recovery and explicit support/feedback consent. Cross-tenant access is limited to the Group Travel workspace contract below.


### PR DESCRIPTION
## Why

Make the public website roadmap visibly traceable from the ratified plan so Phase 0 design work and gated Phase 1B implementation cannot become untracked side work.

Refs #94
Refs #93

## Approach

Add both GitHub issue links to the authoritative public website section and their corresponding Phase 0/Phase 1B deliverables. Record a content-addressed ADR 0000 logged amendment with no architecture, phase, budget, publication, or ratification change.

## Charter impact

Strengthens integrity, accountability, evidence ownership, and human stop gates by making execution tracking explicit. It creates no public claim, deployment, data flow, spend, legal approval, or publication authority.

## Validation

- `python .github\scripts\check_docs_consistency.py` - passed; plan hash, 19 skill rows, and 23 connector categories match.
- `git diff --check` - passed.
- GitHub issues exist and have Phase 0 / Phase 1B milestones.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A