### PR TITLE
Automate unambiguous issue status tracking

### DIFF
--- a/.github/scripts/fixtures/issue-status-events.json
+++ b/.github/scripts/fixtures/issue-status-events.json
@@ -1,0 +1,164 @@
+[
+  {
+    "name": "new issue starts in backlog",
+    "eventName": "issues",
+    "action": "opened",
+    "issueState": "open",
+    "currentLabels": [],
+    "expectedStatus": "status:backlog"
+  },
+  {
+    "name": "branch creation exposes branch-only",
+    "eventName": "create",
+    "action": null,
+    "issueState": "open",
+    "branchLinked": true,
+    "currentLabels": ["status:backlog"],
+    "expectedStatus": "status:branch-only"
+  },
+  {
+    "name": "draft pull request is explicit",
+    "eventName": "pull_request_target",
+    "action": "opened",
+    "issueState": "open",
+    "pullRequests": [{ "state": "open", "isDraft": true, "baseRef": "main" }],
+    "currentLabels": ["status:branch-only"],
+    "expectedStatus": "status:pr-draft"
+  },
+  {
+    "name": "ready pull request is explicit",
+    "eventName": "pull_request_target",
+    "action": "ready_for_review",
+    "issueState": "open",
+    "pullRequests": [{ "state": "open", "isDraft": false, "baseRef": "main" }],
+    "currentLabels": ["status:pr-draft"],
+    "expectedStatus": "status:ready"
+  },
+  {
+    "name": "converted draft returns to draft status",
+    "eventName": "pull_request_target",
+    "action": "converted_to_draft",
+    "issueState": "open",
+    "pullRequests": [{ "state": "open", "isDraft": true, "baseRef": "main" }],
+    "currentLabels": ["status:ready"],
+    "expectedStatus": "status:pr-draft"
+  },
+  {
+    "name": "merge to default branch is merged",
+    "eventName": "pull_request_target",
+    "action": "closed",
+    "issueState": "closed",
+    "defaultBranch": "main",
+    "pullRequests": [{ "state": "closed", "merged": true, "baseRef": "main" }],
+    "currentLabels": ["status:ready"],
+    "expectedStatus": "status:merged"
+  },
+  {
+    "name": "merge to stack branch is not merged to main",
+    "eventName": "pull_request_target",
+    "action": "closed",
+    "issueState": "open",
+    "defaultBranch": "main",
+    "pullRequests": [{ "state": "closed", "merged": true, "baseRef": "feature/base" }],
+    "currentLabels": ["status:ready"],
+    "expectedStatus": "status:branch-only"
+  },
+  {
+    "name": "closed without merge is closed",
+    "eventName": "issues",
+    "action": "closed",
+    "issueState": "closed",
+    "pullRequests": [{ "state": "closed", "merged": false, "baseRef": "main" }],
+    "currentLabels": ["status:ready"],
+    "expectedStatus": "status:closed"
+  },
+  {
+    "name": "reopened issue recomputes lifecycle",
+    "eventName": "issues",
+    "action": "reopened",
+    "issueState": "open",
+    "pullRequests": [{ "state": "open", "isDraft": false, "baseRef": "main" }],
+    "currentLabels": ["status:closed"],
+    "expectedStatus": "status:ready"
+  },
+  {
+    "name": "reopened issue does not remain merged from history",
+    "eventName": "issues",
+    "action": "reopened",
+    "issueState": "open",
+    "defaultBranch": "main",
+    "pullRequests": [{ "state": "closed", "merged": true, "baseRef": "main" }],
+    "currentLabels": ["status:merged"],
+    "expectedStatus": "status:backlog"
+  },
+  {
+    "name": "merge event wins before issue close is observed",
+    "eventName": "pull_request_target",
+    "action": "closed",
+    "issueState": "open",
+    "defaultBranch": "main",
+    "mergeEvent": true,
+    "pullRequests": [{ "state": "closed", "merged": true, "baseRef": "main" }],
+    "currentLabels": ["status:ready"],
+    "expectedStatus": "status:merged"
+  },
+  {
+    "name": "evidence and human dependencies do not replace lifecycle",
+    "eventName": "issues",
+    "action": "edited",
+    "issueState": "open",
+    "pullRequests": [{ "state": "open", "isDraft": false, "baseRef": "main" }],
+    "dependencies": [
+      { "state": "open", "labels": ["blocks:evidence"] },
+      { "state": "open", "labels": [{ "name": "blocks:human" }] },
+      { "state": "closed", "labels": ["blocks:evidence"] }
+    ],
+    "currentLabels": ["status:blocked"],
+    "expectedStatus": "status:ready",
+    "expectedBlockers": ["blocked:evidence", "blocked:human"]
+  },
+  {
+    "name": "unclassified dependency is visible",
+    "eventName": "issues",
+    "action": "edited",
+    "issueState": "open",
+    "dependencies": [{ "state": "open", "labels": [] }],
+    "currentLabels": ["status:backlog"],
+    "expectedStatus": "status:backlog",
+    "expectedBlockers": ["blocked:dependency"]
+  },
+  {
+    "name": "known manual label overrides derived status",
+    "eventName": "issues",
+    "action": "labeled",
+    "appliedLabel": "status:branch-only",
+    "issueState": "open",
+    "pullRequests": [{ "state": "open", "isDraft": false, "baseRef": "main" }],
+    "currentLabels": ["status:ready", "status:branch-only"],
+    "expectedStatus": "status:branch-only"
+  },
+  {
+    "name": "workflow dispatch overrides status and blockers",
+    "eventName": "workflow_dispatch",
+    "action": null,
+    "inputs": {
+      "lifecycle": "closed",
+      "blockers": "evidence-and-human"
+    },
+    "issueState": "open",
+    "currentLabels": ["status:backlog", "blocked:dependency"],
+    "expectedStatus": "status:closed",
+    "expectedBlockers": ["blocked:evidence", "blocked:human"]
+  },
+  {
+    "name": "unknown status label is removed and cannot override",
+    "eventName": "issues",
+    "action": "labeled",
+    "appliedLabel": "status:mystery",
+    "issueState": "open",
+    "currentLabels": ["status:mystery", "area:product"],
+    "expectedStatus": "status:backlog",
+    "expectedRemoved": ["status:mystery"],
+    "expectedPreserved": ["area:product"]
+  }
+]

--- a/.github/scripts/issue-status.js
+++ b/.github/scripts/issue-status.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const STATUS = Object.freeze({
+  BACKLOG: 'status:backlog',
+  BRANCH_ONLY: 'status:branch-only',
+  PR_DRAFT: 'status:pr-draft',
+  READY: 'status:ready',
+  MERGED: 'status:merged',
+  CLOSED: 'status:closed',
+});
+
+const KNOWN_STATUSES = new Set(Object.values(STATUS));
+const MANAGED_BLOCKERS = new Set([
+  'blocked:dependency',
+  'blocked:evidence',
+  'blocked:human',
+]);
+
+function labelNames(labels = []) {
+  return labels.map((label) => typeof label === 'string' ? label : label.name);
+}
+
+function normalizeStatus(value) {
+  if (!value || value === 'auto') {
+    return null;
+  }
+
+  const candidate = value.startsWith('status:') ? value : `status:${value}`;
+  if (!KNOWN_STATUSES.has(candidate)) {
+    throw new Error(`Unknown lifecycle status: ${value}`);
+  }
+
+  return candidate;
+}
+
+function deriveStatus({
+  issueState = 'open',
+  pullRequests = [],
+  branchLinked = false,
+  defaultBranch = 'main',
+  mergeEvent = false,
+} = {}) {
+  const normalizedPullRequests = pullRequests.map((pullRequest) => ({
+    state: String(pullRequest.state || '').toLowerCase(),
+    isDraft: Boolean(pullRequest.isDraft ?? pullRequest.draft),
+    merged: Boolean(pullRequest.merged || pullRequest.merged_at),
+    baseRef: pullRequest.baseRef || pullRequest.base?.ref,
+  }));
+
+  if (String(issueState).toLowerCase() === 'closed') {
+    return normalizedPullRequests.some((pullRequest) =>
+      pullRequest.merged && pullRequest.baseRef === defaultBranch)
+      ? STATUS.MERGED
+      : STATUS.CLOSED;
+  }
+
+  if (mergeEvent && normalizedPullRequests.some((pullRequest) =>
+    pullRequest.merged && pullRequest.baseRef === defaultBranch)) {
+    return STATUS.MERGED;
+  }
+
+  const openPullRequests = normalizedPullRequests.filter(
+    (pullRequest) => pullRequest.state === 'open');
+  if (openPullRequests.some((pullRequest) => !pullRequest.isDraft)) {
+    return STATUS.READY;
+  }
+
+  if (openPullRequests.some((pullRequest) => pullRequest.isDraft)) {
+    return STATUS.PR_DRAFT;
+  }
+
+  if (branchLinked || normalizedPullRequests.some((pullRequest) =>
+    !pullRequest.merged || pullRequest.baseRef !== defaultBranch)) {
+    return STATUS.BRANCH_ONLY;
+  }
+
+  return STATUS.BACKLOG;
+}
+
+function classifyDependencies(dependencies = []) {
+  const blockers = new Set();
+
+  for (const dependency of dependencies) {
+    if (String(dependency.state).toLowerCase() === 'closed') {
+      continue;
+    }
+
+    const labels = new Set(labelNames(dependency.labels));
+    let classified = false;
+    if (labels.has('blocks:evidence')) {
+      blockers.add('blocked:evidence');
+      classified = true;
+    }
+    if (labels.has('blocks:human')) {
+      blockers.add('blocked:human');
+      classified = true;
+    }
+    if (!classified) {
+      blockers.add('blocked:dependency');
+    }
+  }
+
+  return [...blockers].sort();
+}
+
+function manualBlockers(value) {
+  switch (value) {
+    case undefined:
+    case null:
+    case '':
+    case 'auto':
+      return null;
+    case 'none':
+      return [];
+    case 'dependency':
+      return ['blocked:dependency'];
+    case 'evidence':
+      return ['blocked:evidence'];
+    case 'human':
+      return ['blocked:human'];
+    case 'evidence-and-human':
+      return ['blocked:evidence', 'blocked:human'];
+    default:
+      throw new Error(`Unknown blocker override: ${value}`);
+  }
+}
+
+function statusOverrideForEvent({ eventName, action, appliedLabel, inputs = {} }) {
+  if (eventName === 'workflow_dispatch') {
+    return normalizeStatus(inputs.lifecycle);
+  }
+
+  if (eventName === 'issues' && action === 'labeled' &&
+      KNOWN_STATUSES.has(appliedLabel)) {
+    return appliedLabel;
+  }
+
+  return null;
+}
+
+function planLabelUpdate({
+  currentLabels = [],
+  desiredStatus,
+  blockerLabels = [],
+}) {
+  if (!KNOWN_STATUSES.has(desiredStatus)) {
+    throw new Error(`Cannot apply unknown lifecycle status: ${desiredStatus}`);
+  }
+
+  const current = new Set(labelNames(currentLabels));
+  const desired = new Set([desiredStatus, ...blockerLabels]);
+  const remove = [];
+
+  for (const label of current) {
+    if (label.startsWith('status:') && label !== desiredStatus) {
+      remove.push(label);
+    } else if (MANAGED_BLOCKERS.has(label) && !desired.has(label)) {
+      remove.push(label);
+    }
+  }
+
+  const add = [...desired].filter((label) => !current.has(label));
+  return {
+    add: add.sort(),
+    remove: remove.sort(),
+  };
+}
+
+function resolveEvent(fixture) {
+  const statusOverride = statusOverrideForEvent(fixture);
+  const desiredStatus = statusOverride || deriveStatus(fixture);
+  const blockerOverride = fixture.eventName === 'workflow_dispatch'
+    ? manualBlockers(fixture.inputs?.blockers)
+    : null;
+  const blockerLabels = blockerOverride ?? classifyDependencies(fixture.dependencies);
+
+  return {
+    desiredStatus,
+    blockerLabels,
+    plan: planLabelUpdate({
+      currentLabels: fixture.currentLabels,
+      desiredStatus,
+      blockerLabels,
+    }),
+  };
+}
+
+module.exports = {
+  KNOWN_STATUSES,
+  MANAGED_BLOCKERS,
+  STATUS,
+  classifyDependencies,
+  deriveStatus,
+  labelNames,
+  manualBlockers,
+  normalizeStatus,
+  planLabelUpdate,
+  resolveEvent,
+  statusOverrideForEvent,
+};

--- a/.github/scripts/issue-status.test.js
+++ b/.github/scripts/issue-status.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  KNOWN_STATUSES,
+  normalizeStatus,
+  resolveEvent,
+} = require('./issue-status');
+const {
+  issueNumberFromBranch,
+  issueNumbersFromBody,
+} = require('./run-issue-status');
+
+const fixtures = JSON.parse(fs.readFileSync(
+  path.join(__dirname, 'fixtures', 'issue-status-events.json'),
+  'utf8'));
+
+for (const fixture of fixtures) {
+  test(fixture.name, () => {
+    const result = resolveEvent(fixture);
+    assert.equal(result.desiredStatus, fixture.expectedStatus);
+    assert.deepEqual(result.blockerLabels, fixture.expectedBlockers || []);
+
+    const resultingStatuses = new Set([
+      ...fixture.currentLabels
+        .map((label) => typeof label === 'string' ? label : label.name)
+        .filter((label) => label.startsWith('status:') &&
+          !result.plan.remove.includes(label)),
+      ...result.plan.add.filter((label) => label.startsWith('status:')),
+    ]);
+    assert.deepEqual([...resultingStatuses], [fixture.expectedStatus]);
+
+    for (const label of fixture.expectedRemoved || []) {
+      assert.ok(result.plan.remove.includes(label));
+    }
+    for (const label of fixture.expectedPreserved || []) {
+      assert.ok(!result.plan.remove.includes(label));
+    }
+  });
+}
+
+test('all known statuses normalize and unknown statuses fail closed', () => {
+  for (const status of KNOWN_STATUSES) {
+    assert.equal(normalizeStatus(status), status);
+  }
+  assert.throws(() => normalizeStatus('mystery'), /Unknown lifecycle status/);
+});
+
+test('branch parser accepts the documented convention only', () => {
+  assert.equal(issueNumberFromBranch('squad/70-fix-status'), 70);
+  assert.equal(issueNumberFromBranch('70-fix-status'), 70);
+  assert.equal(issueNumberFromBranch('feature/no-issue'), null);
+  assert.equal(issueNumberFromBranch('feature/v2-status'), null);
+});
+
+test('closing keyword parser is bounded to explicit local issue references', () => {
+  assert.deepEqual(
+    [...issueNumbersFromBody('Closes #70\nFixes #71\nRelated to #72')],
+    [70, 71]);
+  assert.deepEqual([...issueNumbersFromBody('Closes owner/repo#70')], []);
+});
+
+test('write workflow executes only trusted pinned automation with least privilege', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', 'workflows', 'issue-status.yml'),
+    'utf8');
+
+  assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(
+    workflow,
+    /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/);
+  assert.match(workflow, /contents: read/);
+  assert.match(workflow, /issues: write/);
+  assert.match(workflow, /pull-requests: read/);
+  assert.doesNotMatch(workflow, /contents: write/);
+  assert.doesNotMatch(workflow, /createComment/);
+
+  const actionReferences = [...workflow.matchAll(/uses:\s+\S+@(\S+)/g)];
+  assert.ok(actionReferences.length > 0);
+  for (const [, reference] of actionReferences) {
+    assert.match(reference, /^[0-9a-f]{40}$/);
+  }
+});

--- a/.github/scripts/run-issue-status.js
+++ b/.github/scripts/run-issue-status.js
@@ -1,0 +1,322 @@
+'use strict';
+
+const {
+  STATUS,
+  classifyDependencies,
+  deriveStatus,
+  manualBlockers,
+  planLabelUpdate,
+  statusOverrideForEvent,
+} = require('./issue-status');
+
+const LABELS = Object.freeze({
+  [STATUS.BACKLOG]: ['D4E5F7', 'Open with no tracked implementation branch or pull request'],
+  [STATUS.BRANCH_ONLY]: ['5319E7', 'Implementation branch exists without an open pull request'],
+  [STATUS.PR_DRAFT]: ['BFD4F2', 'A linked pull request is still draft'],
+  [STATUS.READY]: ['0E8A16', 'A linked pull request is ready for review'],
+  [STATUS.MERGED]: ['6F42C1', 'A linked pull request merged to the default branch'],
+  [STATUS.CLOSED]: ['6A737D', 'Issue closed without a merge to the default branch'],
+  'blocked:dependency': ['B60205', 'Unresolved issue dependency; lifecycle status remains independent'],
+  'blocked:evidence': ['D93F0B', 'Unresolved dependency classified as external or exit evidence'],
+  'blocked:human': ['FBCA04', 'Unresolved dependency classified as a human decision or approval'],
+  'blocks:evidence': ['D93F0B', 'Classifies this issue as an evidence dependency for blocked issues'],
+  'blocks:human': ['FBCA04', 'Classifies this issue as a human decision dependency for blocked issues'],
+});
+
+function issueNumberFromBranch(branch) {
+  const match = String(branch || '').match(/^(?:squad\/)?(\d+)(?:-|$)/);
+  return match ? Number(match[1]) : null;
+}
+
+function issueNumbersFromBody(body) {
+  const numbers = new Set();
+  const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+  for (const match of String(body || '').matchAll(pattern)) {
+    numbers.add(Number(match[1]));
+  }
+  return numbers;
+}
+
+async function ensureLabel({ github, context, name }) {
+  const [color, description] = LABELS[name];
+  try {
+    const { data } = await github.rest.issues.getLabel({ ...context.repo, name });
+    if (data.color.toLowerCase() !== color.toLowerCase() ||
+        data.description !== description) {
+      await github.rest.issues.updateLabel({
+        ...context.repo,
+        name,
+        color,
+        description,
+      });
+    }
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+    await github.rest.issues.createLabel({
+      ...context.repo,
+      name,
+      color,
+      description,
+    });
+  }
+}
+
+async function listDependencies({ github, context, issueNumber, direction }) {
+  const endpoint = direction === 'blocking' ? 'blocking' : 'blocked_by';
+  return github.paginate(
+    `GET /repos/{owner}/{repo}/issues/{issue_number}/dependencies/${endpoint}`,
+    {
+      ...context.repo,
+      issue_number: issueNumber,
+      per_page: 100,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+}
+
+async function linkedPullRequests({ github, context, issueNumber }) {
+  const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+    ...context.repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  const pullRequestNumbers = new Set();
+
+  for (const event of events) {
+    const sourceIssue = event.source?.issue;
+    if (event.event === 'cross-referenced' && sourceIssue?.pull_request) {
+      pullRequestNumbers.add(sourceIssue.number);
+    }
+  }
+
+  const pullRequests = [];
+  for (const pullNumber of [...pullRequestNumbers].slice(0, 100)) {
+    const { data } = await github.rest.pulls.get({
+      ...context.repo,
+      pull_number: pullNumber,
+    });
+    if (!issueNumbersFromBody(data.body).has(issueNumber)) {
+      continue;
+    }
+    pullRequests.push({
+      state: data.state,
+      isDraft: data.draft,
+      merged: data.merged,
+      baseRef: data.base.ref,
+    });
+  }
+  return pullRequests;
+}
+
+async function closingIssueNumbers({ github, context, pullRequest }) {
+  const numbers = issueNumbersFromBody(pullRequest.body);
+  const result = await github.graphql(
+    `query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          closingIssuesReferences(first: 100) {
+            nodes { number }
+          }
+        }
+      }
+    }`,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      number: pullRequest.number,
+    });
+  for (const issue of result.repository.pullRequest.closingIssuesReferences.nodes) {
+    numbers.add(issue.number);
+  }
+  return numbers;
+}
+
+async function expandBlockingIssues({ github, context, issueNumbers }) {
+  const expanded = new Set(issueNumbers);
+  for (const issueNumber of issueNumbers) {
+    const blockedIssues = await listDependencies({
+      github,
+      context,
+      issueNumber,
+      direction: 'blocking',
+    });
+    for (const issue of blockedIssues) {
+      expanded.add(issue.number);
+    }
+  }
+  return expanded;
+}
+
+async function targetIssueNumbers({ github, context }) {
+  const payload = context.payload;
+  let issueNumbers = new Set();
+
+  if (context.eventName === 'workflow_dispatch') {
+    const requested = String(payload.inputs?.issue_number || '').trim();
+    if (requested) {
+      issueNumbers.add(Number(requested));
+    } else {
+      const issues = await github.paginate(github.rest.issues.listForRepo, {
+        ...context.repo,
+        state: 'all',
+        per_page: 100,
+      });
+      issueNumbers = new Set(
+        issues.filter((issue) => !issue.pull_request).map((issue) => issue.number));
+    }
+  } else if (context.eventName === 'issues') {
+    issueNumbers.add(payload.issue.number);
+  } else if (context.eventName === 'pull_request_target') {
+    issueNumbers = await closingIssueNumbers({
+      github,
+      context,
+      pullRequest: payload.pull_request,
+    });
+  } else if (context.eventName === 'create' || context.eventName === 'delete') {
+    const issueNumber = issueNumberFromBranch(payload.ref);
+    if (payload.ref_type === 'branch' && issueNumber) {
+      issueNumbers.add(issueNumber);
+    }
+  }
+
+  return expandBlockingIssues({ github, context, issueNumbers });
+}
+
+async function applyPlan({ github, context, core, issueNumber, plan }) {
+  for (const label of plan.add) {
+    await ensureLabel({ github, context, name: label });
+  }
+  if (plan.add.length > 0) {
+    await github.rest.issues.addLabels({
+      ...context.repo,
+      issue_number: issueNumber,
+      labels: plan.add,
+    });
+  }
+
+  for (const label of plan.remove) {
+    try {
+      await github.rest.issues.removeLabel({
+        ...context.repo,
+        issue_number: issueNumber,
+        name: label,
+      });
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  if (plan.add.length === 0 && plan.remove.length === 0) {
+    core.info(`Issue #${issueNumber}: status labels already reconciled`);
+  } else {
+    core.info(
+      `Issue #${issueNumber}: added [${plan.add.join(', ')}], ` +
+      `removed [${plan.remove.join(', ')}]`);
+  }
+}
+
+async function reconcileIssue({ github, context, core, issueNumber, primaryIssue }) {
+  const { data: issue } = await github.rest.issues.get({
+    ...context.repo,
+    issue_number: issueNumber,
+  });
+  if (issue.pull_request) {
+    return;
+  }
+
+  const pullRequests = await linkedPullRequests({
+    github,
+    context,
+    issueNumber,
+  });
+  const dependencies = await listDependencies({
+    github,
+    context,
+    issueNumber,
+    direction: 'blocked_by',
+  });
+  const appliedLabel = context.payload.label?.name;
+  const eventOverride = primaryIssue
+    ? statusOverrideForEvent({
+      eventName: context.eventName,
+      action: context.payload.action,
+      appliedLabel,
+      inputs: context.payload.inputs,
+    })
+    : null;
+  const desiredStatus = eventOverride || deriveStatus({
+    issueState: issue.state,
+    pullRequests,
+    branchLinked:
+      (context.eventName === 'create' && primaryIssue) ||
+      (context.eventName !== 'delete' &&
+        issue.labels.some((label) => label.name === STATUS.BRANCH_ONLY)),
+    defaultBranch: context.payload.repository.default_branch,
+    mergeEvent:
+      context.eventName === 'pull_request_target' &&
+      context.payload.action === 'closed' &&
+      context.payload.pull_request.merged === true,
+  });
+  const blockerOverride = context.eventName === 'workflow_dispatch' && primaryIssue
+    ? manualBlockers(context.payload.inputs?.blockers)
+    : null;
+  const blockerLabels = blockerOverride ?? classifyDependencies(dependencies);
+  const plan = planLabelUpdate({
+    currentLabels: issue.labels,
+    desiredStatus,
+    blockerLabels,
+  });
+
+  await applyPlan({ github, context, core, issueNumber, plan });
+}
+
+async function run({ github, context, core }) {
+  if (context.eventName === 'pull_request_target' &&
+      context.payload.pull_request.head.repo.full_name !==
+      context.payload.repository.full_name) {
+    core.info('Ignoring fork pull request: write-capable status tracking only trusts repository branches');
+    return;
+  }
+
+  const issueNumbers = await targetIssueNumbers({ github, context });
+  if (issueNumbers.size === 0) {
+    core.info('No linked issue to reconcile');
+    return;
+  }
+
+  for (const name of Object.keys(LABELS)) {
+    await ensureLabel({ github, context, name });
+  }
+
+  const primaryIssueNumber = context.eventName === 'issues'
+    ? context.payload.issue.number
+    : context.eventName === 'workflow_dispatch' &&
+      String(context.payload.inputs?.issue_number || '').trim()
+      ? Number(context.payload.inputs.issue_number)
+      : context.eventName === 'create' || context.eventName === 'delete'
+        ? issueNumberFromBranch(context.payload.ref)
+        : null;
+
+  for (const issueNumber of issueNumbers) {
+    await reconcileIssue({
+      github,
+      context,
+      core,
+      issueNumber,
+      primaryIssue: issueNumber === primaryIssueNumber,
+    });
+  }
+}
+
+module.exports = {
+  LABELS,
+  closingIssueNumbers,
+  issueNumberFromBranch,
+  issueNumbersFromBody,
+  run,
+};

--- a/.github/skills/git-workflow/SKILL.md
+++ b/.github/skills/git-workflow/SKILL.md
@@ -52,8 +52,11 @@ git worktree add ..\Andreja-42 -b squad/42-fix-login origin/main
 
 ## Issue workflow
 
-1. Add `status:in-progress` and the accountable `squad:{member}` label.
-2. Create or reuse the isolated issue worktree after preflight.
+1. Add the accountable `squad:{member}` label. Do not manually replace the
+   issue's single lifecycle `status:*` label.
+2. Create or reuse the isolated issue worktree after preflight, using the
+   documented issue-number branch convention so status automation exposes
+   `status:branch-only`.
 3. Open a draft PR only after an initial coherent commit and required local
    validation.
 4. Keep issue and PR updated with dependencies, evidence, risks, and blockers.

--- a/.github/skills/iterative-retrieval/SKILL.md
+++ b/.github/skills/iterative-retrieval/SKILL.md
@@ -36,8 +36,10 @@ Example:
 ## Escalation path
 {What the agent should do if uncertain or stuck. "Stop and ask me" is valid.}
 Example:
-- If requirements are ambiguous → stop, comment on the issue, set label status:needs-decision
-- If blocked by a dependency → label status:blocked, explain in a comment
+- If requirements are ambiguous → stop, open/link a decision issue labeled
+  `blocks:human`, and explain what decision is required
+- If blocked by a dependency → add a native `Blocked by` relationship; classify
+  the blocker with `blocks:evidence` or `blocks:human` when applicable
 - If 3 cycles exhausted without resolution → write a summary to inbox and surface to coordinator
 ```
 
@@ -57,8 +59,8 @@ Example:
    before accepting it or spawning the next cycle.
 2. **Objective context forward**: each subsequent spawn includes a summary of what was tried
    and what is still missing — not just a repeat of the original task.
-3. **Cycle 3 exhausted** → escalate: write a summary to `.squad/decisions/inbox/`, label the
-   issue `status:needs-decision`, and notify the user.
+3. **Cycle 3 exhausted** → escalate: write a summary to `.squad/decisions/inbox/`,
+   open/link a `blocks:human` decision issue, and notify the user.
 
 ---
 

--- a/.github/skills/session-recovery/SKILL.md
+++ b/.github/skills/session-recovery/SKILL.md
@@ -120,7 +120,9 @@ WHERE sr.ref_type = 'issue'
 ORDER BY s.updated_at DESC;
 ```
 
-Cross-reference with `gh issue list --label "status:in-progress"` to find issues that are marked in-progress but have no active session.
+Cross-reference with `gh issue list` for `status:branch-only`,
+`status:pr-draft`, and `status:ready` to find active implementation issues with
+no active session.
 
 ### 7. Resume a Session
 

--- a/.github/workflows/issue-status-tests.yml
+++ b/.github/workflows/issue-status-tests.yml
@@ -1,0 +1,46 @@
+name: Issue Status Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/issue-status.js'
+      - '.github/scripts/run-issue-status.js'
+      - '.github/scripts/issue-status.test.js'
+      - '.github/scripts/fixtures/issue-status-events.json'
+      - '.github/workflows/issue-status.yml'
+      - '.github/workflows/issue-status-tests.yml'
+      - '.github/workflows/squad-label-enforce.yml'
+      - '.github/workflows/sync-squad-labels.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/scripts/issue-status.js'
+      - '.github/scripts/run-issue-status.js'
+      - '.github/scripts/issue-status.test.js'
+      - '.github/scripts/fixtures/issue-status-events.json'
+      - '.github/workflows/issue-status.yml'
+      - '.github/workflows/issue-status-tests.yml'
+      - '.github/workflows/squad-label-enforce.yml'
+      - '.github/workflows/sync-squad-labels.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Fixture and unit tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22.18.0'
+
+      - name: Run issue-status tests
+        run: node --test .github/scripts/issue-status.test.js

--- a/.github/workflows/issue-status.yml
+++ b/.github/workflows/issue-status.yml
@@ -1,0 +1,59 @@
+name: Issue Status
+
+on:
+  issues:
+  pull_request_target:
+    types: [opened, edited, reopened, closed, converted_to_draft, ready_for_review, synchronize]
+  create:
+  delete:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number; leave blank to reconcile every issue
+        required: false
+        type: string
+      lifecycle:
+        description: One-run lifecycle override
+        required: true
+        default: auto
+        type: choice
+        options: [auto, backlog, branch-only, pr-draft, ready, merged, closed]
+      blockers:
+        description: One-run blocker display override
+        required: true
+        default: auto
+        type: choice
+        options: [auto, none, dependency, evidence, human, evidence-and-human]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-status-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Check out trusted default-branch automation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Reconcile lifecycle and dependency labels
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const runner = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/run-issue-status.js`);
+            await runner.run({ github, context, core });

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Parse roster and sync labels
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -98,6 +100,23 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
+            const STATUS_LABELS = [
+              { name: 'status:backlog', color: 'D4E5F7', description: 'Open with no tracked implementation branch or pull request' },
+              { name: 'status:branch-only', color: '5319E7', description: 'Implementation branch exists without an open pull request' },
+              { name: 'status:pr-draft', color: 'BFD4F2', description: 'A linked pull request is still draft' },
+              { name: 'status:ready', color: '0E8A16', description: 'A linked pull request is ready for review' },
+              { name: 'status:merged', color: '6F42C1', description: 'A linked pull request merged to the default branch' },
+              { name: 'status:closed', color: '6A737D', description: 'Issue closed without a merge to the default branch' }
+            ];
+
+            const DEPENDENCY_LABELS = [
+              { name: 'blocked:dependency', color: 'B60205', description: 'Unresolved issue dependency; lifecycle status remains independent' },
+              { name: 'blocked:evidence', color: 'D93F0B', description: 'Unresolved dependency classified as external or exit evidence' },
+              { name: 'blocked:human', color: 'FBCA04', description: 'Unresolved dependency classified as a human decision or approval' },
+              { name: 'blocks:evidence', color: 'D93F0B', description: 'Classifies this issue as an evidence dependency for blocked issues' },
+              { name: 'blocks:human', color: 'FBCA04', description: 'Classifies this issue as a human decision dependency for blocked issues' }
+            ];
+
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
 
             // Ensure the base "squad" triage label exists
@@ -122,11 +141,13 @@ jobs:
               });
             }
 
-            // Add go:, release:, type:, priority:, and high-signal labels
+            // Add managed namespace and high-signal labels
             labels.push(...GO_LABELS);
             labels.push(...RELEASE_LABELS);
             labels.push(...TYPE_LABELS);
             labels.push(...PRIORITY_LABELS);
+            labels.push(...STATUS_LABELS);
+            labels.push(...DEPENDENCY_LABELS);
             labels.push(...SIGNAL_LABELS);
 
             // Sync labels (create or update)

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -33,8 +33,9 @@ Each platform tracks issue lifecycle differently. Squad normalizes these into a 
 |--------------|-------------------|-------------------|
 | Open, no assignee | `state: open`, `assignee: null` | `untriaged` |
 | Open, assigned, no branch | `state: open`, `assignee: @user`, no linked PR | `assigned` |
-| Open, branch exists | `state: open`, linked branch exists | `inProgress` |
-| Open, PR opened | `state: open`, PR exists, `reviewDecision: null` | `needsReview` |
+| Open, branch exists | `state: open`, linked branch exists | `branchOnly` |
+| Open, draft PR | `state: open`, PR `isDraft: true` | `draft` |
+| Open, ready PR | `state: open`, PR `isDraft: false` | `needsReview` |
 | Open, PR approved | `state: open`, PR `reviewDecision: APPROVED` | `readyToMerge` |
 | Open, changes requested | `state: open`, PR `reviewDecision: CHANGES_REQUESTED` | `changesRequested` |
 | Open, CI failure | `state: open`, PR `statusCheckRollup: FAILURE` | `ciFailure` |
@@ -47,6 +48,10 @@ Each platform tracks issue lifecycle differently. Squad normalizes these into a 
 - `go:needs-research` — Needs investigation before implementation
 - `priority:p{N}` — Priority level (0=critical, 1=high, 2=medium, 3=low)
 - `next-up` — Queued for next agent pickup
+- Exactly one lifecycle label: `status:backlog`, `status:branch-only`,
+  `status:pr-draft`, `status:ready`, `status:merged`, or `status:closed`
+- Independent dependency labels: `blocked:dependency`, `blocked:evidence`, and
+  `blocked:human`; classify blockers with `blocks:evidence` or `blocks:human`
 
 **Branch naming convention:**
 ```
@@ -401,6 +406,8 @@ All PRs reviewed → All PRs merged → Epic closed
 - ❌ Leaving feature branches undeleted after merge
 - ❌ Using `checkout -b` when parallel agents are active (causes working directory conflicts)
 - ❌ Manually transitioning issue states — let the platform and Squad automation handle it
+- ❌ Using `status:blocked` or `status:needs-decision` — blockers are independent
+  `blocked:*` labels and never replace lifecycle
 - ❌ Skipping the branch naming convention — breaks Ralph's tracking logic
 
 ## Migration Notes

--- a/.squad/templates/skills/git-workflow/SKILL.md
+++ b/.squad/templates/skills/git-workflow/SKILL.md
@@ -52,8 +52,11 @@ git worktree add ..\Andreja-42 -b squad/42-fix-login origin/main
 
 ## Issue workflow
 
-1. Add `status:in-progress` and the accountable `squad:{member}` label.
-2. Create or reuse the isolated issue worktree after preflight.
+1. Add the accountable `squad:{member}` label. Do not manually replace the
+   issue's single lifecycle `status:*` label.
+2. Create or reuse the isolated issue worktree after preflight, using the
+   documented issue-number branch convention so status automation exposes
+   `status:branch-only`.
 3. Open a draft PR only after an initial coherent commit and required local
    validation.
 4. Keep issue and PR updated with dependencies, evidence, risks, and blockers.

--- a/.squad/templates/skills/iterative-retrieval/SKILL.md
+++ b/.squad/templates/skills/iterative-retrieval/SKILL.md
@@ -36,8 +36,10 @@ Example:
 ## Escalation path
 {What the agent should do if uncertain or stuck. "Stop and ask me" is valid.}
 Example:
-- If requirements are ambiguous → stop, comment on the issue, set label status:needs-decision
-- If blocked by a dependency → label status:blocked, explain in a comment
+- If requirements are ambiguous → stop, open/link a decision issue labeled
+  `blocks:human`, and explain what decision is required
+- If blocked by a dependency → add a native `Blocked by` relationship; classify
+  the blocker with `blocks:evidence` or `blocks:human` when applicable
 - If 3 cycles exhausted without resolution → write a summary to inbox and surface to coordinator
 ```
 
@@ -57,8 +59,8 @@ Example:
    before accepting it or spawning the next cycle.
 2. **Objective context forward**: each subsequent spawn includes a summary of what was tried
    and what is still missing — not just a repeat of the original task.
-3. **Cycle 3 exhausted** → escalate: write a summary to `.squad/decisions/inbox/`, label the
-   issue `status:needs-decision`, and notify the user.
+3. **Cycle 3 exhausted** → escalate: write a summary to `.squad/decisions/inbox/`,
+   open/link a `blocks:human` decision issue, and notify the user.
 
 ---
 

--- a/.squad/templates/skills/ralph-two-pass-scan/SKILL.md
+++ b/.squad/templates/skills/ralph-two-pass-scan/SKILL.md
@@ -28,8 +28,8 @@ gh issue list --state open --json number,title,labels,assignees --limit 100
 | Condition | Skip reason |
 |-----------|-------------|
 | `assignees` non-empty AND no `status:needs-review` | Already owned |
-| Labels contain `status:blocked` or `status:waiting-external` | Externally gated |
-| Labels contain `status:done` or `status:postponed` | Closed loop |
+| Labels contain any `blocked:*` label | Dependency gated; lifecycle remains visible |
+| Labels contain `status:merged` or `status:closed` | Closed loop |
 | Title matches stale/noisy pattern (`[chore]`, `[auto]`) | Low-signal |
 
 ### Pass 2 — Selective Hydration

--- a/.squad/templates/skills/session-recovery/SKILL.md
+++ b/.squad/templates/skills/session-recovery/SKILL.md
@@ -120,7 +120,9 @@ WHERE sr.ref_type = 'issue'
 ORDER BY s.updated_at DESC;
 ```
 
-Cross-reference with `gh issue list --label "status:in-progress"` to find issues that are marked in-progress but have no active session.
+Cross-reference with `gh issue list` for `status:branch-only`,
+`status:pr-draft`, and `status:ready` to find active implementation issues with
+no active session.
 
 ### 7. Resume a Session
 

--- a/.squad/templates/workflows/sync-squad-labels.yml
+++ b/.squad/templates/workflows/sync-squad-labels.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Parse roster and sync labels
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -98,6 +100,23 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
+            const STATUS_LABELS = [
+              { name: 'status:backlog', color: 'D4E5F7', description: 'Open with no tracked implementation branch or pull request' },
+              { name: 'status:branch-only', color: '5319E7', description: 'Implementation branch exists without an open pull request' },
+              { name: 'status:pr-draft', color: 'BFD4F2', description: 'A linked pull request is still draft' },
+              { name: 'status:ready', color: '0E8A16', description: 'A linked pull request is ready for review' },
+              { name: 'status:merged', color: '6F42C1', description: 'A linked pull request merged to the default branch' },
+              { name: 'status:closed', color: '6A737D', description: 'Issue closed without a merge to the default branch' }
+            ];
+
+            const DEPENDENCY_LABELS = [
+              { name: 'blocked:dependency', color: 'B60205', description: 'Unresolved issue dependency; lifecycle status remains independent' },
+              { name: 'blocked:evidence', color: 'D93F0B', description: 'Unresolved dependency classified as external or exit evidence' },
+              { name: 'blocked:human', color: 'FBCA04', description: 'Unresolved dependency classified as a human decision or approval' },
+              { name: 'blocks:evidence', color: 'D93F0B', description: 'Classifies this issue as an evidence dependency for blocked issues' },
+              { name: 'blocks:human', color: 'FBCA04', description: 'Classifies this issue as a human decision dependency for blocked issues' }
+            ];
+
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
 
             // Ensure the base "squad" triage label exists
@@ -122,11 +141,13 @@ jobs:
               });
             }
 
-            // Add go:, release:, type:, priority:, and high-signal labels
+            // Add managed namespace and high-signal labels
             labels.push(...GO_LABELS);
             labels.push(...RELEASE_LABELS);
             labels.push(...TYPE_LABELS);
             labels.push(...PRIORITY_LABELS);
+            labels.push(...STATUS_LABELS);
+            labels.push(...DEPENDENCY_LABELS);
             labels.push(...SIGNAL_LABELS);
 
             // Sync labels (create or update)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ dotnet format Andreja.slnx --verify-no-changes --no-restore
 dotnet format tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj `
   --verify-no-changes --no-restore
 python .github\scripts\check_docs_consistency.py
+node --test .github\scripts\issue-status.test.js
 pwsh -NoProfile -File .github\scripts\invoke-nuget-vulnerability-scan.ps1
 pwsh -NoProfile -File scripts\operations\validate-contract.ps1
 pwsh -NoProfile -File scripts\supply-chain\Test-SupplyChainPolicy.ps1

--- a/docs/help/issue-status.md
+++ b/docs/help/issue-status.md
@@ -1,0 +1,41 @@
+# Issue status and blockers
+
+GitHub issues use one `status:*` label for implementation and pull-request
+lifecycle:
+
+| Label | Meaning |
+|---|---|
+| `status:backlog` | Open; no tracked branch or pull request |
+| `status:branch-only` | Implementation branch or closed unmerged PR exists |
+| `status:pr-draft` | A linked pull request is draft |
+| `status:ready` | A linked pull request is ready for review |
+| `status:merged` | A linked pull request merged to the default branch |
+| `status:closed` | Closed without a merge to the default branch |
+
+`status:ready` does not mean approved, checks-passing, or mergeable. Read the
+pull request's required checks and reviews before merging. A stack layer merged
+only into another feature branch remains `status:branch-only` until its work
+reaches the default branch.
+
+## Dependencies and evidence
+
+Use GitHub's **Blocked by** relationship. An unresolved ordinary dependency adds
+`blocked:dependency` to the dependent issue. Add `blocks:evidence` to a blocker
+that exists to produce external or milestone-exit proof; dependents then show
+`blocked:evidence`. Add `blocks:human` to a blocker that requires a recorded
+human decision or approval; dependents then show `blocked:human`.
+
+These labels never replace `status:*`. An issue can correctly be both
+`status:merged` and `blocked:evidence`.
+
+## Automatic and manual repair
+
+The Issue Status workflow reacts to issue lifecycle, documented branch names
+(`squad/<issue>-<slug>`), and trusted same-repository pull requests that close an
+issue. It is idempotent and does not post comments.
+
+From **Actions > Issue Status > Run workflow**, leave the issue number blank to
+reconcile all issues, or enter one issue number. `auto` derives lifecycle and
+blockers. A selected lifecycle or blocker value is a one-run override; the next
+relevant event derives state again. Adding a recognized `status:*` label directly
+is also a one-event manual override. Unknown `status:*` labels are removed.

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -122,11 +122,20 @@ RACI pattern for cross-workstream issues:
 | **Consulted (C)** | Specialist whose artifact gate applies (security, privacy, legal, cost, quality, RAI, fact-check) | Named per the "Artifact gates" table below, invoked only when their gate is due |
 | **Informed (I)** | Notified via issue comment/handoff note but not blocking | Coordinator, Guinan (user-facing changes), Quark (cost-bearing changes), affected downstream workstream leads |
 
+- Every issue has exactly one lifecycle label. `status:backlog`,
+  `status:branch-only`, `status:pr-draft`, `status:ready`, `status:merged`, and
+  `status:closed` describe only implementation/PR state. `status:ready` means
+  ready for review, not approved, checks-passing, or safe to merge.
 - Dependencies between issues are expressed with GitHub's "Depends on" /
-  "Blocked by" issue links and the `status:blocked` label, never a private
-  tracking sheet.
-- An issue with unresolved dependencies stays `status:blocked` until the
-  dependency merges; the Coordinator re-evaluates readiness at each triage pass.
+  "Blocked by" links, never a private tracking sheet. Unresolved links add
+  `blocked:dependency` without replacing lifecycle status. Classify the blocking
+  issue with `blocks:evidence` or `blocks:human` when it represents external/exit
+  evidence or an explicit human decision; dependents then expose
+  `blocked:evidence` or `blocked:human`.
+- A dependency closes only when its own outcome is complete. Code may therefore
+  be `status:ready` or `status:merged` while exit evidence remains
+  `blocked:evidence`; neither label implies that required checks, reviews,
+  approvals, or milestone gates passed.
 - Reassignment happens by removing one `squad:{member}` label and adding another;
   the issue history preserves the accountability trail.
 
@@ -150,10 +159,9 @@ due for that issue.
 
 Batch related artifacts into themed review packets with at most three
 evidence/revision cycles (per `.squad/directives.md`); unresolved items become
-explicit decision issues (tag `type:decision`; adopt the dedicated
-`status:needs-decision` label from "Recommended follow-up" below once it
-exists) instead of silently blocking unrelated packets. Silence is never
-approval.
+explicit decision issues (tag `type:decision`; use the
+`blocks:human` label when the decision blocks another issue) instead of
+silently blocking unrelated packets. Silence is never approval.
 
 ## Handoff format
 
@@ -173,7 +181,8 @@ creating a second backlog; Scribe logs automatically and never blocks.
 
 ## WIP limits
 
-- Each workstream lead limits concurrent `status:in-progress` issues to what one
+- Each workstream lead limits concurrent `status:branch-only`,
+  `status:pr-draft`, and `status:ready` issues to what one
   accountable owner can carry through review without queuing rejected work.
   Finish (merge or explicitly park with a recorded reason) before starting new
   work in the same file/module ownership area.
@@ -192,6 +201,14 @@ creating a second backlog; Scribe logs automatically and never blocks.
 - Every implementation issue gets a `squad/{issue-number}-{kebab-case-slug}`
   branch cut from the current integration branch, a sibling isolated worktree,
   one accountable owning agent, and an early draft PR.
+- `.github/workflows/issue-status.yml` derives lifecycle from issue, branch, and
+  trusted same-repository PR events. It reads automation only from the default
+  branch, makes idempotent label writes, posts no comments, and never executes
+  pull-request code with a write token. A workflow dispatch may reconcile all
+  issues or make a one-run manual override; the next lifecycle event derives
+  state again.
+- Operator-facing label meanings and repair steps live in
+  [`docs/help/issue-status.md`](help/issue-status.md).
 - Agents never switch another worktree's branch, edit another agent's files, or
   share mutable build/output directories.
 - **Independent issues:** run concurrently in separate worktrees, each with its
@@ -396,18 +413,16 @@ not introduce a parallel prioritization taxonomy — that belongs to issue #5.
 **Recommended follow-up (non-blocking):** several workstreams (Web/UX, Mobile,
 Ops/Hosting, Channels, Skills, Customer Success, Marketing) currently share a
 broader `area:*` label with another workstream because no dedicated label
-exists yet. Two ceremonies referenced above also need dedicated labels that do
-not exist today: `retro-action` (for Retrospective-with-Enforcement action
-items, `.squad/ceremonies.md`) and `status:needs-decision` (for artifact-gate
-items awaiting Cyrus's decision, "Artifact gates" above). Picard should open a
-small `type:governance` issue to add `area:web-ux`, `area:mobile`, `area:ops`,
+exists yet. One ceremony referenced above also needs a dedicated label that
+does not exist today: `retro-action` (for Retrospective-with-Enforcement action
+items, `.squad/ceremonies.md`). Human decisions are represented by a
+`blocks:human` dependency rather than a second lifecycle status. Picard should
+open a small `type:governance` issue to add `area:web-ux`, `area:mobile`, `area:ops`,
 `area:channels`, `area:skills`, `area:customer-success`, `area:marketing`,
-`retro-action`, and `status:needs-decision` labels via
+and `retro-action` labels via
 `.github/workflows/sync-squad-labels.yml` once ratified, rather than expanding
 this document's scope to create labels unilaterally. Until that issue lands,
-use the existing `type:decision` label plus a body reference for
-needs-decision items, and `type:chore` plus a link to the retrospective issue
-for retro-action items.
+use `type:chore` plus a link to the retrospective issue for retro-action items.
 
 ## Cross-references
 


### PR DESCRIPTION
## Why

Issue lifecycle labels currently conflate implementation progress with milestone exit evidence, making it difficult to tell whether work is branch-only, review-ready, merged to main, or still blocked by external evidence or a human decision. This change makes those dimensions explicit while preserving issue closure behavior and blocker issues such as #44 and #62.

Closes #70

## Approach

Add a deterministic, idempotent status reconciler that enforces exactly one known `status:*` label and independently manages `blocked:dependency`, `blocked:evidence`, and `blocked:human`. The trusted default-branch workflow derives state from issue, same-repository PR, and documented branch events; it never executes untrusted PR code, uses least-privilege permissions, pins third-party actions, and does not post comments.

Fixture-driven Node tests cover issue and PR transitions, reopened and closed issues, draft and ready PRs, main and stacked merges, dependencies, manual overrides, unknown labels, parser boundaries, workflow trust, and idempotency. Operating-model, workflow, recovery, and user-help guidance now use the same lifecycle vocabulary.

## Charter impact

This improves human agency and evidence quality by separating implementation state from external proof and human approvals. It does not introduce personal data, AI inference, credentials, connector content, new services, or new ownership boundaries. The workflow fails closed on unknown lifecycle overrides and preserves explicit stop conditions through blocker relationships.

## Validation

- `node --test .github/scripts/issue-status.test.js` - PASS, 20/20 tests
- `pwsh -NoProfile -File scripts\supply-chain\Test-SupplyChainPolicy.ps1` - PASS; workflow permissions, action pins, base images, and Compose image pins valid
- `git diff --check` and `git diff --cached --check` - PASS
- `node --check .github\scripts\issue-status.js` - PASS
- `node --check .github\scripts\run-issue-status.js` - PASS

Automated required checks and reviews remain pending on this draft PR.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A. This is an independent PR targeting `main`.