### PR TITLE
Fix Squad state MCP tool allowlist

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,19 @@
       ],
       "env": {},
       "tools": [
-        "*"
+        "squad_decide",
+        "squad_state_read",
+        "squad_state_write",
+        "squad_state_append",
+        "squad_state_delete",
+        "squad_state_list",
+        "squad_state_health",
+        "memory.classify",
+        "memory.write",
+        "memory.search",
+        "memory.promote",
+        "memory.delete",
+        "memory.audit"
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,8 +7,7 @@
       ],
       "env": {},
       "tools": [
-        "squad_state_*",
-        "memory.*"
+        "*"
       ]
     }
   }


### PR DESCRIPTION
## Why

The Squad runtime state bridge was configured but its tools were absent from Copilot sessions. Copilot treats the MCP `tools` entries as explicit selectors rather than glob patterns, so the prior `squad_state_*` and `memory.*` entries exposed nothing.

Closes: N/A

## Approach

Enumerate the 13 tools currently exported by `squad state-mcp` as exact selectors for the `squad_state` MCP server. This restores the required state and governed-memory capabilities while preventing future tools from being granted implicitly.

## Charter impact

Not applicable: this configuration-only correction changes tool discovery, not product behavior, user data handling, or stakeholder policy.

## Validation

- JSON parse: passed
- MCP `tools/list` comparison: `.mcp.json` exactly enumerates all 13 currently exported tools
- `copilot mcp get squad_state`: reported the 13 explicit selectors
- `copilot -p ... --additional-mcp-config '@.mcp.json'`: invoked `squad_state_health` and returned `State backend storage: StateBackendStorageAdapter`
- `git diff --check`: passed

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A.