### PR TITLE
test: evaluate xUnit v3 and MSTest/MTP

### DIFF
--- a/docs/adr/0007-test-framework.md
+++ b/docs/adr/0007-test-framework.md
@@ -3,6 +3,7 @@
 - **Status:** Proposed (amended; not accepted)
 - **Date:** 2026-08-24
 - **Amended:** 2026-08-25
+- **Evidence refreshed:** 2026-08-28
 - **Issue:** [#96](https://github.com/Jamula/Andreja/issues/96)
 - **Migration issue:** [#112](https://github.com/Jamula/Andreja/issues/112)
 - **Governing:** [Platform plan](../plan.md#phase-1a---self-hosted-assistant-walking-skeleton),
@@ -27,6 +28,31 @@ PostgreSQL inventory parity, CI/TRX/IDE evidence, package/provenance review,
 performance evidence, independent quality/architecture review, and rollback.
 No production or test source, package, runner, or workflow migration is in scope
 for this amendment.
+
+## 2026-08-28 issue #108 evidence refresh
+
+[Issue #108's bounded evidence](../research/test-platform-evidence-108.md)
+compared current stable xUnit.net v3 (`xunit.v3` 4.0.0, native MTP 2.3.3)
+against `MSTest.Sdk` 4.3.3/MTP 2.3.3 on the pinned .NET SDK 10.0.301.
+Equivalent Debug/Release and filtered spikes preserved data expansion, async
+lifecycle, class/cross-class fixture behavior, explicit concurrency,
+skip/timeout/output, WebApplicationFactory authentication boundaries, EF
+migration metadata, TRX, and telemetry opt-out controls. Neither candidate
+crossed the 10% sustained full-run regression stop threshold.
+
+The evidence supports retaining Cyrus's existing long-term MSTest/MTP direction.
+It does not establish a performance winner, accept this Proposed ADR, or
+authorize conversion. The production xUnit 2 suite remains unchanged.
+
+Live PostgreSQL and graphical Visual Studio/VS Code execution were unavailable
+on the evidence host and are explicitly blocked rather than inferred. The
+MSTest spike's lazy class-requested shared owner did not initialize for an
+unrelated filter, addressing the earlier eager assembly-fixture concern at
+prototype level. Its custom lifecycle still requires full production review.
+Issue #112 remains the only migration owner and must prove exact Debug/Release
+and live-PostgreSQL inventory parity, IDE/CI/TRX behavior, extension profile
+licenses, package provenance, telemetry controls, performance, review, and
+rollback before any suite change.
 
 The original recommendation, measurements, risks, and stop conditions below are
 retained as historical investigation evidence for #112. Where they recommend

--- a/docs/adr/0007-test-framework.md
+++ b/docs/adr/0007-test-framework.md
@@ -36,9 +36,11 @@ compared current stable xUnit.net v3 (`xunit.v3` 4.0.0, native MTP 2.3.3)
 against `MSTest.Sdk` 4.3.3/MTP 2.3.3 on the pinned .NET SDK 10.0.301.
 Equivalent Debug/Release and filtered spikes preserved data expansion, async
 lifecycle, class/cross-class fixture behavior, explicit concurrency,
-skip/timeout/output, WebApplicationFactory authentication boundaries, EF
-migration metadata, TRX, and telemetry opt-out controls. Neither candidate
-crossed the 10% sustained full-run regression stop threshold.
+skip/output, WebApplicationFactory authentication boundaries, EF migration
+metadata, TRX, and telemetry opt-out controls. Isolated negative probes also
+verified that both candidates enforce cooperative timeout/cancellation without
+changing normal inventory. Warm-run order was counterbalanced and the 10% gate
+used a tested mathematical median. Neither candidate crossed the threshold.
 
 The evidence supports retaining Cyrus's existing long-term MSTest/MTP direction.
 It does not establish a performance winner, accept this Proposed ADR, or

--- a/docs/research/test-platform-evidence-108.md
+++ b/docs/research/test-platform-evidence-108.md
@@ -1,0 +1,160 @@
+# Issue 108: xUnit v3 and MSTest/MTP evidence
+
+- **Evidence date:** 2026-08-28
+- **Host:** Windows arm64; .NET SDK 10.0.301
+- **Scope:** bounded local/paper evidence only; no cloud account, trial, production
+  suite migration, or product behavior change
+- **Reproduction:** [`scripts/evidence/test-platform-spike`](../../scripts/evidence/test-platform-spike/)
+
+## Outcome and authority
+
+**Decision already recorded:** Cyrus selected MSTest with Microsoft Testing
+Platform as Andreja's long-term direction in the ratified plan status amendment
+and [issue #112](https://github.com/Jamula/Andreja/issues/112).
+
+**Recommendation from this evidence:** retain that direction. `MSTest.Sdk`
+4.3.3/MTP 2.3.3 preserved the representative semantics and evidence below,
+adds stronger observed analyzer enforcement, is Microsoft-supported, and did
+not cross the 10% sustained full-run regression stop threshold. This is not a
+performance-win claim; the small samples do not identify a decision-grade
+performance winner.
+
+**Approval boundary:** ADR 0007 remains **Proposed**. This research does not
+claim Cyrus accepted the ADR or authorize migration. Issue #112 owns the later
+atomic production-suite conversion, exact parity, CI/IDE/live-PostgreSQL proof,
+review, and rollback.
+
+## Current first-party evidence
+
+All sources in this section were accessed 2026-08-28.
+
+| Concern | xUnit.net v3 | MSTest.Sdk/MTP | Fact and consequence |
+| --- | --- | --- | --- |
+| Current stable candidate | [`xunit.v3` 4.0.0](https://www.nuget.org/packages/xunit.v3/4.0.0), published 2026-08-15 ([catalog metadata](https://api.nuget.org/v3/catalog0/data/2026.08.15.01.53.55/xunit.v3.4.0.0.json)). The package major is 4, but the product generation remains xUnit.net v3. | [`MSTest.Sdk` 4.3.3](https://www.nuget.org/packages/MSTest.Sdk/4.3.3) and [MTP 2.3.3](https://www.nuget.org/packages/Microsoft.Testing.Platform/2.3.3), both published 2026-07-28 ([SDK](https://api.nuget.org/v3/catalog0/data/2026.07.28.07.35.43/mstest.sdk.4.3.3.json), [MTP](https://api.nuget.org/v3/catalog0/data/2026.07.28.07.35.43/microsoft.testing.platform.2.3.3.json)). | These were the latest listed stable versions in the NuGet version indexes. Both restored, built, discovered, and ran on pinned SDK 10.0.301/net10.0. |
+| Support and maintenance | The [xUnit home page](https://xunit.net/) identifies v3 as the feature line, lists 4.0.0 as current, and limits v2 to critical fixes. xUnit is community-focused, part of the .NET Foundation, and [project-lead governed](https://xunit.net/governance). No dedicated security-policy file appeared in its [repository community profile](https://api.github.com/repos/xunit/xunit/community/profile) during review. | The [MSTest overview](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-intro) calls MSTest fully supported and open source, recommends MTP/MSTest.Sdk for new projects, and supports only the latest release. [MSTest running guidance](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-running-tests) calls its MTP runner the recommended path. | xUnit v3 is actively maintained but has no Microsoft support commitment. MSTest has an explicit Microsoft support statement, paired with an ongoing latest-release upgrade obligation. |
+| Runtime compatibility | The [`xunit.v3` package](https://www.nuget.org/packages/xunit.v3/4.0.0) supports .NET 8+; 4.0.0 installs `xunit.v3.mtp-v2`. [Native MTP guidance](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) says xUnit v3 4.0+ defaults to MTP v2. | [MTP](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro) supports .NET 8+ and is embedded in test executables. `MSTest.Sdk` enables MTP by default per [SDK configuration](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk). | Both resolved MTP 2.3.3 in the spike. Neither candidate needs `Microsoft.NET.Test.Sdk` or a VSTest adapter for this native-MTP configuration. |
+| License and provenance | `xunit.v3` metadata declares Apache-2.0, repository commit `8bf043c053fc133ad9da67709942e1dfb18583ea`, and a SHA-512 package hash. `dotnet nuget verify --all` verified xUnit.net/.NET Foundation author and NuGet.org repository signatures for `xunit.v3` and `xunit.v3.mtp-v2`. | MSTest.Sdk and MTP metadata declare MIT and repository commit `44aa76e6a61d4908f06dfd77a51d4b7e3e7ce40f`; [testfx's license](https://github.com/microsoft/testfx/blob/main/LICENSE) is MIT. Microsoft author and NuGet.org repository signatures verified for SDK/framework/adapter/MTP. [MSRC reporting](https://github.com/microsoft/testfx/security/policy) is documented. | The MSTest `Default` profile also resolved `Microsoft.Testing.Extensions.CodeCoverage` 18.9.0 under Microsoft .NET Library terms, not MIT. Profile and extension licenses require explicit review in #112. Signature verification establishes package signing/provenance, not absence of malicious or vulnerable code. |
+| Advisories | `dotnet list package --vulnerable --include-transitive` reported no known vulnerable package in either resolved graph from the configured source. | Same result. | Point-in-time advisory evidence only; it is not proof of absence. |
+| Runner and `dotnet test` | xUnit's [MTP guide](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) documents executable tests, native MTP, `global.json`, and xUnit-provided MTP options. | [.NET 10 `dotnet test`](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test) requires `"test": {"runner": "Microsoft.Testing.Platform"}`, `--project`/`--solution`, and MTP options. MTP 2 removes .NET 10's legacy VSTest-mode bridge. | Andreja's current `dotnet test Andreja.slnx --logger ...` commands cannot carry over. Mixed VSTest/MTP mode remains unsupported, so #112 must cut the projects, root runner selection, commands, and CI together. |
+| Filtering | Native xUnit MTP used `--filter-trait "Category=Smoke"`; xUnit also documents class/method filters and its query language. | MSTest used `--filter "TestCategory=Smoke"` as documented in [MSTest running guidance](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-running-tests). | The equivalent filters selected six result rows. Framework-specific switches differ; [.NET guidance](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test#solutions-with-mixed-test-frameworks-or-extensions) warns that passing one framework's option to another can fail. |
+| TRX and artifacts | The native package exposed xUnit's `--report-xunit-trx`; it produced a parseable TRX with output and skip evidence. | The SDK `Default` profile includes TRX and uses `--report-trx`. [MTP report guidance](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-test-reports) documents deterministic names and streaming TRX writes in 2.3+. | Both produced exact result counters. The differing switches require explicit CI design unless #112 adds and reviews a common reporting extension to xUnit. |
+| Analyzers | `xunit.analyzers` 2.0.0 resolved transitively and the clean spike built with warnings as errors. It did not flag the conditional always-true assertion probe. | `MSTest.Analyzers` 4.3.3 resolved transitively. `MSTestAnalysisMode=Recommended` failed the equivalent probe with `MSTEST0032`. The [analyzer reference](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/overview) documents framework, async, lifecycle, assertion, and data rules. | This repeats issue #96's stronger observed MSTest analyzer finding with current candidates. It is one probe, not a count or quality comparison of every rule. |
+| Telemetry | xUnit v3 4.0.0 resolved `Microsoft.Testing.Extensions.Telemetry` 2.3.3. xUnit's MTP page explicitly documents `TESTINGPLATFORM_TELEMETRY_OPTOUT=1`. | MSTest/MTP resolved the same telemetry extension. [MTP telemetry](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-telemetry) says collection is on when the extension is present, lists usage fields, and accepts either `TESTINGPLATFORM_TELEMETRY_OPTOUT=1` or `DOTNET_CLI_TELEMETRY_OPTOUT=1`. | Both spike paths ran with both opt-outs set. Andreja already sets `DOTNET_CLI_TELEMETRY_OPTOUT=1` in CI; #112 must preserve and test that control. Self-host product telemetry remains unrelated and off by default. |
+| Visual Studio and VS Code | The [xUnit MTP page](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform) documents current Visual Studio MTP Test Explorer integration. | [MTP run/debug guidance](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-run-and-debug) documents run/debug/Test Explorer support in Visual Studio and VS Code with C# Dev Kit. | Neither graphical IDE was installed on the evidence host. Support is first-party documented but local discovery/debug parity remains unobserved and belongs to #112. |
+| Lifecycle and concurrency | [xUnit shared context](https://xunit.net/docs/shared-context) provides async lifetime, class, collection, and assembly fixtures. [Parallel guidance](https://xunit.net/docs/running-tests-in-parallel) keeps collection-level parallelism on by default. | [MSTest lifecycle](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-writing-tests-lifecycle) provides async assembly/class/test scopes. [Execution controls](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-writing-tests-controlling-execution) say execution is sequential by default and requires explicit `Parallelize`. | Migration is semantic, not an attribute-only rewrite. The spike explicitly enabled MSTest class-level parallelism and used a lazy, class-requested shared owner so unrelated filters did not initialize the fixture. |
+
+The [MTP overview](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro),
+[CLI options](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options),
+and [run/debug guide](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-run-and-debug)
+are the common first-party operational references.
+
+## Local production baseline
+
+No production test source, package, runner, or workflow was changed. Fresh
+per-assembly inventory from the current branch:
+
+| Configuration / assembly | Discovered | TRX total | Executed | Passed | Failed | Skipped |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Debug `Andreja.UnitTests` | 256 | 257 | 257 | 257 | 0 | 0 |
+| Debug `Andreja.ArchitectureTests` | 18 | 18 | 18 | 18 | 0 | 0 |
+| **Debug service-free total** | **274** | **275** | **275** | **275** | **0** | **0** |
+| Release `Andreja.UnitTests` | 252 | 253 | 253 | 253 | 0 | 0 |
+| Release `Andreja.ArchitectureTests` | 18 | 18 | 18 | 18 | 0 | 0 |
+| **Release service-free total** | **270** | **271** | **271** | **271** | **0** | **0** |
+
+The Debug/Release difference is the existing conditional compilation boundary.
+In both configurations,
+`PortabilityCommandTests.InfrastructureFailuresUseFixedContentMinimizedMessages`
+is one non-pre-enumerated discovery case and two runtime rows. PostgreSQL
+discovery remained 22 in both configurations.
+
+## Equivalent spike results
+
+The committed harness references Andreja's real AppHost and adapters but is not
+in the production solution.
+
+| Configuration / candidate | Discovered | TRX total | Executed | Passed | Failed | Skipped |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Debug xUnit v3/MTP | 12 | 13 | 12 | 12 | 0 | 1 |
+| Debug MSTest/MTP | 13 | 13 | 12 | 12 | 0 | 1 |
+| Release xUnit v3/MTP | 12 | 13 | 12 | 12 | 0 | 1 |
+| Release MSTest/MTP | 13 | 13 | 12 | 12 | 0 | 1 |
+| Filtered xUnit v3/MTP | n/a | 6 | 5 | 5 | 0 | 1 |
+| Filtered MSTest/MTP | n/a | 6 | 5 | 5 | 0 | 1 |
+
+xUnit intentionally deferred enumeration of its exception-bearing `MemberData`;
+one discovery case expanded to two execution results. MSTest discovered its two
+typed `DynamicData` rows. Both TRX files contained the intentional skip and
+captured output.
+
+Both candidates also passed:
+
+- async initialize/cleanup markers;
+- class fixture lifetime and one shared fixture instance across two classes;
+- two-class concurrency rendezvous;
+- bounded timeout/cancellation;
+- anonymous Andreja API `401` and rejection of
+  `X-Andreja-Test-Authenticate`;
+- discovery of all six production EF migrations without a database connection;
+- Debug/Release MTP executable operation and deterministic TRX creation.
+
+The MSTest shared-resource prototype uses class initialization to request one
+lazy owner and assembly cleanup that disposes only if created. A Smoke-only
+filter left its start marker absent. This removes issue #96's eager
+assembly-initialization defect, but it is custom static lifecycle code rather
+than xUnit's named collection-fixture abstraction. #112 must review its
+thread-safety, failure, and cleanup behavior before adapting it to PostgreSQL.
+
+## Timing, repetition, and memory
+
+Measurements used restored/built projects on one Windows arm64 host. They are
+representative guardrails, not benchmarks.
+
+| Measurement | xUnit v3/MTP | MSTest/MTP |
+| --- | ---: | ---: |
+| Five warm full runs, min / median / max | 1,249 / 1,341 / 1,456 ms | 1,162 / 1,222 / 1,809 ms |
+| One clean build + full run | 2,293 ms | 2,153 ms |
+| Sampled direct-runner largest-process working set | 99.4 MiB | 90.9 MiB |
+
+MSTest's warm median was 8.9% faster and its clean build/run was 6.1% faster.
+One MSTest warm run was a high outlier. Neither candidate crossed the 10%
+sustained regression stop condition. Five stabilized
+timing runs plus the final Debug, Release, filter, and direct-executable runs
+had no intermittent failure. Memory is approximate and excludes child/process
+tree aggregation.
+
+Early discarded harness iterations exposed a missing Identity model setup and
+an unsupported cancellation-token parameter shape. They were symmetric harness
+or probe defects, corrected before measurement, and are not framework
+reliability results.
+
+## Package and security result
+
+- xUnit had two direct spike packages; MSTest.Sdk materialized five top-level
+  test packages under its `Default` profile. Both shared the same AppHost
+  dependency graph and MTP 2.3.3.
+- `dotnet nuget verify --all` passed for the candidate framework, runner, MTP,
+  and MSTest default code-coverage packages.
+- The point-in-time direct/transitive vulnerability query reported no known
+  vulnerable packages from the configured package source.
+- Dynamic MTP extensions are disabled by default according to the
+  [CLI reference](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options).
+
+## Bounded blockers and remaining gates
+
+1. **Live PostgreSQL:** no `ANDREJA_TEST_POSTGRES` value, container engine, or
+   listener on local port 5432 was available. The 22-test project compiled and
+   listed in Debug/Release, but runtime was correctly recorded **blocked**, not
+   passed or skipped. Issue #96 remains prior live xUnit-2/MSTest evidence;
+   xUnit-v3 live parity remains unobserved.
+2. **IDE:** Visual Studio and VS Code were unavailable. Their documented support
+   was not represented as locally tested.
+3. **Full conversion:** exact production-suite MTP counts, analyzer conversion,
+   filter/FQN behavior, CI artifacts, live PostgreSQL cleanup, and rollback can
+   only be proven on the atomic migration branch owned by #112.
+4. **Profile/license:** #112 must choose and review the MSTest extension profile,
+   especially the non-MIT code-coverage extension, and re-run package signature,
+   advisory, and telemetry evidence.
+
+These gaps do not overturn the existing long-term MSTest direction. They do
+block describing the production suite as migrated or ADR 0007 as accepted.

--- a/docs/research/test-platform-evidence-108.md
+++ b/docs/research/test-platform-evidence-108.md
@@ -92,7 +92,9 @@ Both candidates also passed:
 - async initialize/cleanup markers;
 - class fixture lifetime and one shared fixture instance across two classes;
 - two-class concurrency rendezvous;
-- bounded timeout/cancellation;
+- isolated negative timeout probes that exceeded 250 ms and produced one
+  timeout/cancellation failure per candidate, with a 15-second process kill
+  bound; these conditional probes did not change normal inventory;
 - anonymous Andreja API `401` and rejection of
   `X-Andreja-Test-Authenticate`;
 - discovery of all six production EF migrations without a database connection;
@@ -107,18 +109,20 @@ thread-safety, failure, and cleanup behavior before adapting it to PostgreSQL.
 
 ## Timing, repetition, and memory
 
-Measurements used restored/built projects on one Windows arm64 host. They are
-representative guardrails, not benchmarks.
+Measurements used restored/built projects on one Windows arm64 host. Warm runs
+alternated candidate order. The harness tests its median calculation against
+known odd and even samples before using the mathematical median for the 10%
+gate. These are representative guardrails, not benchmarks.
 
 | Measurement | xUnit v3/MTP | MSTest/MTP |
 | --- | ---: | ---: |
-| Five warm full runs, min / median / max | 1,249 / 1,341 / 1,456 ms | 1,162 / 1,222 / 1,809 ms |
+| Four counterbalanced warm full runs, min / median / max | 1,322 / 1,463.5 / 1,652 ms | 1,264 / 1,319.5 / 1,551 ms |
 | One clean build + full run | 2,293 ms | 2,153 ms |
 | Sampled direct-runner largest-process working set | 99.4 MiB | 90.9 MiB |
 
-MSTest's warm median was 8.9% faster and its clean build/run was 6.1% faster.
+MSTest's warm median was 9.8% faster and its clean build/run was 6.1% faster.
 One MSTest warm run was a high outlier. Neither candidate crossed the 10%
-sustained regression stop condition. Five stabilized
+sustained regression stop condition. Four counterbalanced
 timing runs plus the final Debug, Release, filter, and direct-executable runs
 had no intermittent failure. Memory is approximate and excludes child/process
 tree aggregation.

--- a/scripts/evidence/test-platform-spike/Directory.Packages.props
+++ b/scripts/evidence/test-platform-spike/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/scripts/evidence/test-platform-spike/Invoke-Spike.ps1
+++ b/scripts/evidence/test-platform-spike/Invoke-Spike.ps1
@@ -1,0 +1,210 @@
+[CmdletBinding()]
+param(
+    [string] $Dotnet = "dotnet",
+    [ValidateRange(3, 21)]
+    [int] $WarmRuns = 5
+)
+
+$ErrorActionPreference = "Stop"
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+$env:TESTINGPLATFORM_TELEMETRY_OPTOUT = "1"
+
+if (Test-Path -LiteralPath $Dotnet) {
+    $Dotnet = (Resolve-Path -LiteralPath $Dotnet).Path
+}
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\.."))
+$resultsRoot = Join-Path $repositoryRoot "artifacts\test-platform-spike"
+$xunitProject = "XunitV3Spike\XunitV3Spike.csproj"
+$mstestProject = "MSTestMtpSpike\MSTestMtpSpike.csproj"
+New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+
+function Invoke-Dotnet {
+    param([Parameter(Mandatory)][string[]] $Arguments)
+
+    & $Dotnet @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Assert-TrxCounters {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][int] $Total,
+        [Parameter(Mandatory)][int] $Executed,
+        [Parameter(Mandatory)][int] $Passed,
+        [Parameter(Mandatory)][int] $NotExecuted
+    )
+
+    [xml] $trx = Get-Content -LiteralPath $Path
+    $counters = $trx.TestRun.ResultSummary.Counters
+    $actual = @(
+        [int] $counters.total,
+        [int] $counters.executed,
+        [int] $counters.passed,
+        [int] $counters.failed,
+        [int] $counters.notExecuted
+    )
+    $expected = @($Total, $Executed, $Passed, 0, $NotExecuted)
+    if (Compare-Object $expected $actual -SyncWindow 0) {
+        throw "Unexpected TRX counters in '$Path': $($actual -join '/')."
+    }
+}
+
+function Get-DiscoveryCount {
+    param(
+        [Parameter(Mandatory)][string] $Project,
+        [Parameter(Mandatory)][string] $Configuration,
+        [Parameter(Mandatory)][string] $OutputPath
+    )
+
+    $output = & $Dotnet test --project $Project -c $Configuration --no-build --list-tests 2>&1
+    $output | Set-Content -LiteralPath $OutputPath
+    $output | Write-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Discovery failed for '$Project' ($Configuration)."
+    }
+
+    $match = [regex]::Match(($output -join "`n"), "Discovered (\d+) tests\.")
+    if (-not $match.Success) {
+        throw "Could not parse discovery count for '$Project' ($Configuration)."
+    }
+
+    return [int] $match.Groups[1].Value
+}
+
+Push-Location $PSScriptRoot
+try {
+    Invoke-Dotnet @("restore", $xunitProject)
+    Invoke-Dotnet @("restore", $mstestProject)
+
+    foreach ($configuration in @("Debug", "Release")) {
+        $configurationResults = Join-Path $resultsRoot $configuration
+        New-Item -ItemType Directory -Path $configurationResults -Force | Out-Null
+        Invoke-Dotnet @("build", $xunitProject, "-c", $configuration, "--no-restore")
+        Invoke-Dotnet @("build", $mstestProject, "-c", $configuration, "--no-restore")
+
+        $xunitDiscovered = Get-DiscoveryCount `
+            -Project $xunitProject `
+            -Configuration $configuration `
+            -OutputPath (Join-Path $configurationResults "xunit-list.txt")
+        $mstestDiscovered = Get-DiscoveryCount `
+            -Project $mstestProject `
+            -Configuration $configuration `
+            -OutputPath (Join-Path $configurationResults "mstest-list.txt")
+        if ($xunitDiscovered -ne 12 -or $mstestDiscovered -ne 13) {
+            throw "Unexpected discovery inventory: xUnit=$xunitDiscovered; MSTest=$mstestDiscovered."
+        }
+
+        $xunitLifecycle = Join-Path $configurationResults "xunit-lifecycle.txt"
+        $mstestLifecycle = Join-Path $configurationResults "mstest-lifecycle.txt"
+        $mstestFixture = Join-Path $configurationResults "mstest-fixture.txt"
+        Remove-Item $xunitLifecycle, $mstestLifecycle, $mstestFixture `
+            -Force -ErrorAction SilentlyContinue
+
+        $env:ANDREJA_SPIKE_LIFECYCLE_FILE = $xunitLifecycle
+        Remove-Item Env:ANDREJA_SPIKE_FIXTURE_FILE -ErrorAction SilentlyContinue
+        Invoke-Dotnet @(
+            "test", "--project", $xunitProject, "-c", $configuration, "--no-build",
+            "--report-xunit-trx",
+            "--report-xunit-trx-filename", "XunitV3Spike.$configuration.trx",
+            "--results-directory", $configurationResults
+        )
+
+        $env:ANDREJA_SPIKE_LIFECYCLE_FILE = $mstestLifecycle
+        $env:ANDREJA_SPIKE_FIXTURE_FILE = $mstestFixture
+        Invoke-Dotnet @(
+            "test", "--project", $mstestProject, "-c", $configuration, "--no-build",
+            "--report-trx",
+            "--report-trx-filename", "MSTestMtpSpike.$configuration.trx",
+            "--results-directory", $configurationResults
+        )
+
+        Assert-TrxCounters `
+            -Path (Join-Path $configurationResults "XunitV3Spike.$configuration.trx") `
+            -Total 13 -Executed 12 -Passed 12 -NotExecuted 1
+        Assert-TrxCounters `
+            -Path (Join-Path $configurationResults "MSTestMtpSpike.$configuration.trx") `
+            -Total 13 -Executed 12 -Passed 12 -NotExecuted 1
+        $lifecycleComplete =
+            (Get-Content $xunitLifecycle) -eq "xunit-v3-cleanup" -and
+            (Get-Content $mstestLifecycle) -eq "mstest-mtp-cleanup" -and
+            (Get-Content $mstestFixture) -eq "started;disposed"
+        if (-not $lifecycleComplete) {
+            throw "Lifecycle or shared-fixture cleanup evidence is incomplete."
+        }
+    }
+
+    $filterResults = Join-Path $resultsRoot "filters"
+    New-Item -ItemType Directory -Path $filterResults -Force | Out-Null
+    $unrelatedFixture = Join-Path $filterResults "mstest-unrelated-fixture.txt"
+    Remove-Item $unrelatedFixture -Force -ErrorAction SilentlyContinue
+    Remove-Item Env:ANDREJA_SPIKE_LIFECYCLE_FILE -ErrorAction SilentlyContinue
+    Remove-Item Env:ANDREJA_SPIKE_FIXTURE_FILE -ErrorAction SilentlyContinue
+    Invoke-Dotnet @(
+        "test", "--project", $xunitProject, "-c", "Debug", "--no-build",
+        "--filter-trait", "Category=Smoke",
+        "--report-xunit-trx", "--report-xunit-trx-filename", "XunitV3Spike.Filter.trx",
+        "--results-directory", $filterResults
+    )
+    $env:ANDREJA_SPIKE_FIXTURE_FILE = $unrelatedFixture
+    Invoke-Dotnet @(
+        "test", "--project", $mstestProject, "-c", "Debug", "--no-build",
+        "--filter", "TestCategory=Smoke",
+        "--report-trx", "--report-trx-filename", "MSTestMtpSpike.Filter.trx",
+        "--results-directory", $filterResults
+    )
+    Assert-TrxCounters `
+        -Path (Join-Path $filterResults "XunitV3Spike.Filter.trx") `
+        -Total 6 -Executed 5 -Passed 5 -NotExecuted 1
+    Assert-TrxCounters `
+        -Path (Join-Path $filterResults "MSTestMtpSpike.Filter.trx") `
+        -Total 6 -Executed 5 -Passed 5 -NotExecuted 1
+    if (Test-Path $unrelatedFixture) {
+        throw "The MSTest shared fixture initialized for an unrelated filter."
+    }
+
+    Remove-Item Env:ANDREJA_SPIKE_LIFECYCLE_FILE, Env:ANDREJA_SPIKE_FIXTURE_FILE `
+        -ErrorAction SilentlyContinue
+    $timings = 1..$WarmRuns | ForEach-Object {
+        $xunit = (Measure-Command {
+            Invoke-Dotnet @("test", "--project", $xunitProject, "-c", "Debug", "--no-build")
+        }).TotalMilliseconds
+        $mstest = (Measure-Command {
+            Invoke-Dotnet @("test", "--project", $mstestProject, "-c", "Debug", "--no-build")
+        }).TotalMilliseconds
+        [pscustomobject]@{
+            Run = $_
+            XunitV3Milliseconds = [math]::Round($xunit)
+            MSTestMtpMilliseconds = [math]::Round($mstest)
+        }
+    }
+    $timings | Export-Csv (Join-Path $resultsRoot "warm-runs.csv") -NoTypeInformation
+    $xunitMedian = ($timings.XunitV3Milliseconds | Sort-Object)[[math]::Floor($WarmRuns / 2)]
+    $mstestMedian = ($timings.MSTestMtpMilliseconds | Sort-Object)[[math]::Floor($WarmRuns / 2)]
+    if ($mstestMedian -gt ($xunitMedian * 1.10)) {
+        throw "MSTest median exceeded the 10% stop threshold: $mstestMedian vs $xunitMedian ms."
+    }
+
+    Invoke-Dotnet @(
+        "build", $xunitProject, "-c", "Debug", "--no-restore",
+        "-p:RunAnalyzerProbe=true"
+    )
+    $mstestProbe = & $Dotnet build $mstestProject -c Debug --no-restore `
+        -p:RunAnalyzerProbe=true 2>&1
+    $mstestProbe | Set-Content (Join-Path $resultsRoot "mstest-analyzer-probe.txt")
+    if ($LASTEXITCODE -eq 0 -or ($mstestProbe -join "`n") -notmatch "MSTEST0032") {
+        throw "The MSTest always-true assertion probe did not fail with MSTEST0032."
+    }
+
+    Invoke-Dotnet @("build", $xunitProject, "-c", "Debug", "--no-restore")
+    Invoke-Dotnet @("build", $mstestProject, "-c", "Debug", "--no-restore")
+    Write-Host "Test-platform spike passed. Results: $resultsRoot"
+    Write-Host "Warm medians: xUnit v3 $xunitMedian ms; MSTest/MTP $mstestMedian ms."
+}
+finally {
+    Remove-Item Env:ANDREJA_SPIKE_LIFECYCLE_FILE, Env:ANDREJA_SPIKE_FIXTURE_FILE `
+        -ErrorAction SilentlyContinue
+    Pop-Location
+}

--- a/scripts/evidence/test-platform-spike/Invoke-Spike.ps1
+++ b/scripts/evidence/test-platform-spike/Invoke-Spike.ps1
@@ -28,16 +28,93 @@ function Invoke-Dotnet {
     }
 }
 
+function Invoke-DotnetExpectingTestFailure {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [Parameter(Mandatory)][string] $OutputPath,
+        [int] $TimeoutSeconds = 15
+    )
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $Dotnet
+    $startInfo.WorkingDirectory = $PSScriptRoot
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $Arguments) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        if (-not $process.Start()) {
+            throw "Could not start dotnet for the expected-failure probe."
+        }
+
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+            $process.Kill($true)
+            $process.WaitForExit()
+            throw "Expected-failure probe exceeded the $TimeoutSeconds-second process bound."
+        }
+
+        $output = @(
+            $stdout.GetAwaiter().GetResult()
+            $stderr.GetAwaiter().GetResult()
+        ) -join [Environment]::NewLine
+        $output | Set-Content -LiteralPath $OutputPath
+        $output | Write-Host
+        if ($process.ExitCode -eq 0) {
+            throw "Expected-failure probe unexpectedly exited successfully."
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+function Get-Median {
+    param([Parameter(Mandatory)][double[]] $Values)
+
+    if ($Values.Count -eq 0) {
+        throw "Cannot calculate a median for an empty sample."
+    }
+
+    $sorted = @($Values | Sort-Object)
+    $middle = [math]::Floor($sorted.Count / 2)
+    if (($sorted.Count % 2) -eq 1) {
+        return $sorted[$middle]
+    }
+
+    return ($sorted[$middle - 1] + $sorted[$middle]) / 2
+}
+
+$medianCases = @(
+    @{ Name = "odd"; Values = @(9, 1, 5); Expected = 5 }
+    @{ Name = "even"; Values = @(10, 2, 8, 4); Expected = 6 }
+)
+foreach ($medianCase in $medianCases) {
+    $actualMedian = Get-Median -Values $medianCase.Values
+    if ($actualMedian -ne $medianCase.Expected) {
+        throw "The $($medianCase.Name)-sample median check failed: $actualMedian."
+    }
+}
+
 function Assert-TrxCounters {
     param(
         [Parameter(Mandatory)][string] $Path,
         [Parameter(Mandatory)][int] $Total,
         [Parameter(Mandatory)][int] $Executed,
         [Parameter(Mandatory)][int] $Passed,
-        [Parameter(Mandatory)][int] $NotExecuted
+        [Parameter(Mandatory)][int] $NotExecuted,
+        [string] $ExpectedOutput,
+        [string] $ExpectedSkipReason
     )
 
-    [xml] $trx = Get-Content -LiteralPath $Path
+    $trxContent = Get-Content -LiteralPath $Path -Raw
+    [xml] $trx = $trxContent
     $counters = $trx.TestRun.ResultSummary.Counters
     $actual = @(
         [int] $counters.total,
@@ -49,6 +126,47 @@ function Assert-TrxCounters {
     $expected = @($Total, $Executed, $Passed, 0, $NotExecuted)
     if (Compare-Object $expected $actual -SyncWindow 0) {
         throw "Unexpected TRX counters in '$Path': $($actual -join '/')."
+    }
+    if ($ExpectedOutput -and $trxContent -notmatch [regex]::Escape($ExpectedOutput)) {
+        throw "Expected output marker '$ExpectedOutput' is absent from '$Path'."
+    }
+    if ($ExpectedSkipReason -and $trxContent -notmatch [regex]::Escape($ExpectedSkipReason)) {
+        throw "Expected skip reason '$ExpectedSkipReason' is absent from '$Path'."
+    }
+}
+
+function Assert-TimeoutFailureResult {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $TestName
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Timeout probe did not create '$Path'."
+    }
+
+    [xml] $trx = Get-Content -LiteralPath $Path -Raw
+    $counters = $trx.TestRun.ResultSummary.Counters
+    $actual = @(
+        [int] $counters.total,
+        [int] $counters.executed,
+        [int] $counters.passed,
+        [int] $counters.failed
+    )
+    if (Compare-Object @(1, 1, 0, 1) $actual -SyncWindow 0) {
+        throw "Unexpected timeout-probe counters in '$Path': $($actual -join '/')."
+    }
+
+    $results = @(
+        $trx.SelectNodes("//*[local-name()='UnitTestResult']") |
+            Where-Object { $_.testName -like "*$TestName*" }
+    )
+    if ($results.Count -ne 1 -or $results[0].outcome -notin @("Failed", "Timeout")) {
+        throw "Expected one failed timeout result named '$TestName' in '$Path'."
+    }
+
+    if ($results[0].OuterXml -notmatch "(?i)timeout|timed out|cancel") {
+        throw "The failed result in '$Path' contains no timeout/cancellation evidence."
     }
 }
 
@@ -123,10 +241,14 @@ try {
 
         Assert-TrxCounters `
             -Path (Join-Path $configurationResults "XunitV3Spike.$configuration.trx") `
-            -Total 13 -Executed 12 -Passed 12 -NotExecuted 1
+            -Total 13 -Executed 12 -Passed 12 -NotExecuted 1 `
+            -ExpectedOutput "xunit-v3-output" `
+            -ExpectedSkipReason "intentional evidence skip"
         Assert-TrxCounters `
             -Path (Join-Path $configurationResults "MSTestMtpSpike.$configuration.trx") `
-            -Total 13 -Executed 12 -Passed 12 -NotExecuted 1
+            -Total 13 -Executed 12 -Passed 12 -NotExecuted 1 `
+            -ExpectedOutput "mstest-mtp-output" `
+            -ExpectedSkipReason "intentional evidence skip"
         $lifecycleComplete =
             (Get-Content $xunitLifecycle) -eq "xunit-v3-cleanup" -and
             (Get-Content $mstestLifecycle) -eq "mstest-mtp-cleanup" -and
@@ -157,23 +279,74 @@ try {
     )
     Assert-TrxCounters `
         -Path (Join-Path $filterResults "XunitV3Spike.Filter.trx") `
-        -Total 6 -Executed 5 -Passed 5 -NotExecuted 1
+        -Total 6 -Executed 5 -Passed 5 -NotExecuted 1 `
+        -ExpectedOutput "xunit-v3-output" `
+        -ExpectedSkipReason "intentional evidence skip"
     Assert-TrxCounters `
         -Path (Join-Path $filterResults "MSTestMtpSpike.Filter.trx") `
-        -Total 6 -Executed 5 -Passed 5 -NotExecuted 1
+        -Total 6 -Executed 5 -Passed 5 -NotExecuted 1 `
+        -ExpectedOutput "mstest-mtp-output" `
+        -ExpectedSkipReason "intentional evidence skip"
     if (Test-Path $unrelatedFixture) {
         throw "The MSTest shared fixture initialized for an unrelated filter."
     }
 
     Remove-Item Env:ANDREJA_SPIKE_LIFECYCLE_FILE, Env:ANDREJA_SPIKE_FIXTURE_FILE `
         -ErrorAction SilentlyContinue
+    $timeoutResults = Join-Path $resultsRoot "timeout-probes"
+    New-Item -ItemType Directory -Path $timeoutResults -Force | Out-Null
+    $xunitTimeoutTrx = Join-Path $timeoutResults "XunitV3Spike.Timeout.trx"
+    $mstestTimeoutTrx = Join-Path $timeoutResults "MSTestMtpSpike.Timeout.trx"
+    Remove-Item $xunitTimeoutTrx, $mstestTimeoutTrx -Force -ErrorAction SilentlyContinue
+
+    Invoke-Dotnet @(
+        "build", $xunitProject, "-c", "Debug", "--no-restore",
+        "-p:RunTimeoutProbe=true"
+    )
+    Invoke-DotnetExpectingTestFailure `
+        -Arguments @(
+            "test", "--project", $xunitProject, "-c", "Debug", "--no-build",
+            "--report-xunit-trx",
+            "--report-xunit-trx-filename", "XunitV3Spike.Timeout.trx",
+            "--results-directory", $timeoutResults
+        ) `
+        -OutputPath (Join-Path $timeoutResults "xunit-timeout-output.txt")
+    Assert-TimeoutFailureResult -Path $xunitTimeoutTrx -TestName "TimeoutEnforcementProbe"
+
+    Invoke-Dotnet @(
+        "build", $mstestProject, "-c", "Debug", "--no-restore",
+        "-p:RunTimeoutProbe=true"
+    )
+    Invoke-DotnetExpectingTestFailure `
+        -Arguments @(
+            "test", "--project", $mstestProject, "-c", "Debug", "--no-build",
+            "--report-trx",
+            "--report-trx-filename", "MSTestMtpSpike.Timeout.trx",
+            "--results-directory", $timeoutResults
+        ) `
+        -OutputPath (Join-Path $timeoutResults "mstest-timeout-output.txt")
+    Assert-TimeoutFailureResult -Path $mstestTimeoutTrx -TestName "TimeoutEnforcementProbe"
+
+    Invoke-Dotnet @("build", $xunitProject, "-c", "Debug", "--no-restore")
+    Invoke-Dotnet @("build", $mstestProject, "-c", "Debug", "--no-restore")
+
     $timings = 1..$WarmRuns | ForEach-Object {
-        $xunit = (Measure-Command {
-            Invoke-Dotnet @("test", "--project", $xunitProject, "-c", "Debug", "--no-build")
-        }).TotalMilliseconds
-        $mstest = (Measure-Command {
-            Invoke-Dotnet @("test", "--project", $mstestProject, "-c", "Debug", "--no-build")
-        }).TotalMilliseconds
+        if (($_ % 2) -eq 1) {
+            $xunit = (Measure-Command {
+                Invoke-Dotnet @("test", "--project", $xunitProject, "-c", "Debug", "--no-build")
+            }).TotalMilliseconds
+            $mstest = (Measure-Command {
+                Invoke-Dotnet @("test", "--project", $mstestProject, "-c", "Debug", "--no-build")
+            }).TotalMilliseconds
+        }
+        else {
+            $mstest = (Measure-Command {
+                Invoke-Dotnet @("test", "--project", $mstestProject, "-c", "Debug", "--no-build")
+            }).TotalMilliseconds
+            $xunit = (Measure-Command {
+                Invoke-Dotnet @("test", "--project", $xunitProject, "-c", "Debug", "--no-build")
+            }).TotalMilliseconds
+        }
         [pscustomobject]@{
             Run = $_
             XunitV3Milliseconds = [math]::Round($xunit)
@@ -181,8 +354,8 @@ try {
         }
     }
     $timings | Export-Csv (Join-Path $resultsRoot "warm-runs.csv") -NoTypeInformation
-    $xunitMedian = ($timings.XunitV3Milliseconds | Sort-Object)[[math]::Floor($WarmRuns / 2)]
-    $mstestMedian = ($timings.MSTestMtpMilliseconds | Sort-Object)[[math]::Floor($WarmRuns / 2)]
+    $xunitMedian = Get-Median -Values $timings.XunitV3Milliseconds
+    $mstestMedian = Get-Median -Values $timings.MSTestMtpMilliseconds
     if ($mstestMedian -gt ($xunitMedian * 1.10)) {
         throw "MSTest median exceeded the 10% stop threshold: $mstestMedian vs $xunitMedian ms."
     }

--- a/scripts/evidence/test-platform-spike/Invoke-Spike.ps1
+++ b/scripts/evidence/test-platform-spike/Invoke-Spike.ps1
@@ -2,7 +2,8 @@
 param(
     [string] $Dotnet = "dotnet",
     [ValidateRange(3, 21)]
-    [int] $WarmRuns = 5
+    [int] $WarmRuns = 5,
+    [switch] $ValidateHelpersOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -165,9 +166,63 @@ function Assert-TimeoutFailureResult {
         throw "Expected one failed timeout result named '$TestName' in '$Path'."
     }
 
-    if ($results[0].OuterXml -notmatch "(?i)timeout|timed out|cancel") {
+    # Restrict evidence to the runner's error message; result attributes contain authored identifiers.
+    $diagnosticText = @(
+        $results[0].SelectNodes(
+            "./*[local-name()='Output']/*[local-name()='ErrorInfo']/*[local-name()='Message']"
+        ) | ForEach-Object { $_.InnerText }
+    ) -join [Environment]::NewLine
+    if ($diagnosticText -notmatch "(?i)\b(?:timeout|timed\s+out|cancel(?:led|ed|lation|ling|ing)?)\b") {
         throw "The failed result in '$Path' contains no timeout/cancellation evidence."
     }
+}
+
+function Test-TimeoutDiagnosticAssertion {
+    $regressionPath = Join-Path $resultsRoot "timeout-diagnostic-regression.trx"
+    @'
+<TestRun>
+  <ResultSummary>
+    <Counters total="1" executed="1" passed="0" failed="1" />
+  </ResultSummary>
+  <Results>
+    <UnitTestResult testName="TimeoutNamedButUnrelatedFailure" outcome="Failed">
+      <Output>
+        <ErrorInfo>
+          <Message>Expected values to be equal.</Message>
+        </ErrorInfo>
+      </Output>
+    </UnitTestResult>
+  </Results>
+</TestRun>
+'@ | Set-Content -LiteralPath $regressionPath
+
+    try {
+        $unrelatedFailureRejected = $false
+        try {
+            Assert-TimeoutFailureResult `
+                -Path $regressionPath `
+                -TestName "TimeoutNamedButUnrelatedFailure"
+        }
+        catch {
+            if ($_.Exception.Message -notlike "*contains no timeout/cancellation evidence.") {
+                throw
+            }
+            $unrelatedFailureRejected = $true
+        }
+
+        if (-not $unrelatedFailureRejected) {
+            throw "A test name containing 'Timeout' incorrectly satisfied the diagnostic assertion."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $regressionPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Test-TimeoutDiagnosticAssertion
+if ($ValidateHelpersOnly) {
+    Write-Host "Spike helper regression validation passed."
+    return
 }
 
 function Get-DiscoveryCount {

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/AnalyzerProbe.cs
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/AnalyzerProbe.cs
@@ -1,0 +1,10 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MSTestMtpSpike;
+
+[TestClass]
+public sealed class AnalyzerProbe
+{
+    [TestMethod]
+    public void AlwaysTrueAssertion() => Assert.IsTrue(true);
+}

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/FrameworkEvidenceTests.cs
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/FrameworkEvidenceTests.cs
@@ -1,0 +1,243 @@
+using Andreja.Adapters.PostgreSql;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+
+[assembly: Parallelize(Workers = 2, Scope = ExecutionScope.ClassLevel)]
+
+namespace MSTestMtpSpike;
+
+[TestClass]
+public sealed class BasicAndLifecycleTests(TestContext testContext)
+{
+    private bool initialized;
+
+    [TestInitialize]
+    public void Initialize() => initialized = true;
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        var path = Environment.GetEnvironmentVariable("ANDREJA_SPIKE_LIFECYCLE_FILE");
+        if (path is not null)
+        {
+            await File.WriteAllTextAsync(
+                path,
+                "mstest-mtp-cleanup",
+                testContext.CancellationToken);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void TestMethodAndLifecyclePass()
+    {
+        testContext.WriteLine("mstest-mtp-output");
+        Assert.IsTrue(initialized);
+    }
+
+    [TestMethod]
+    [DataRow(1, 2, 3)]
+    [DataRow(-1, 1, 0)]
+    [TestCategory("Smoke")]
+    public void DataRowsAdd(int left, int right, int expected) =>
+        Assert.AreEqual(expected, left + right);
+
+    public static IEnumerable<(Exception exception, int ordinal)> RuntimeRows =>
+    [
+        (new InvalidOperationException("first"), 1),
+        (new ArgumentException("second"), 2),
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(RuntimeRows))]
+    public void RuntimeExpandedDynamicDataIsAccountedFor(Exception exception, int ordinal)
+    {
+        Assert.IsNotEmpty(exception.Message);
+        Assert.IsGreaterThan(0, ordinal);
+    }
+
+    [TestMethod]
+    [Ignore("intentional evidence skip")]
+    [TestCategory("Smoke")]
+    public void IntentionalSkipIsReported()
+    {
+    }
+
+    [TestMethod]
+    [Timeout(2_000, CooperativeCancellation = true)]
+    [TestCategory("Smoke")]
+    public async Task TimeoutAndCancellationAreBounded() =>
+        await Task.Delay(10, testContext.CancellationToken);
+}
+
+public sealed class AndrejaFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
+        builder.UseEnvironment("Development");
+}
+
+[TestClass]
+public sealed class WebApplicationFactoryTests(TestContext testContext)
+{
+    private static AndrejaFactory factory = null!;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext context) => factory = new AndrejaFactory();
+
+    [ClassCleanup]
+    public static void Cleanup() => factory.Dispose();
+
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public async Task AnonymousApiAndFakeAuthenticationHeaderStayUnauthorized()
+    {
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost"),
+        });
+
+        using var anonymous = await client.GetAsync(
+            "/api/v1/open-loops/tasks",
+            testContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, anonymous.StatusCode);
+
+        client.DefaultRequestHeaders.Add("X-Andreja-Test-Authenticate", "true");
+        using var fakeHeader = await client.GetAsync(
+            "/api/v1/open-loops/tasks",
+            testContext.CancellationToken);
+        Assert.AreEqual(HttpStatusCode.Unauthorized, fakeHeader.StatusCode);
+    }
+}
+
+[TestClass]
+public sealed class EfMigrationMetadataTests
+{
+    [TestMethod]
+    public void ProductionEfMigrationsAreDiscoverableWithoutConnecting()
+    {
+        var migrations = typeof(AndrejaIdentityDbContext).Assembly
+            .GetTypes()
+            .Count(type => type.GetCustomAttribute<MigrationAttribute>() is not null);
+
+        Assert.AreEqual(6, migrations);
+    }
+}
+
+public sealed class SharedFixture : IDisposable
+{
+    public SharedFixture()
+    {
+        var marker = Environment.GetEnvironmentVariable("ANDREJA_SPIKE_FIXTURE_FILE");
+        if (marker is not null)
+        {
+            File.WriteAllText(marker, "started");
+        }
+    }
+
+    public Guid InstanceId { get; } = Guid.NewGuid();
+
+    public void Dispose()
+    {
+        var marker = Environment.GetEnvironmentVariable("ANDREJA_SPIKE_FIXTURE_FILE");
+        if (marker is not null)
+        {
+            File.AppendAllText(marker, ";disposed");
+        }
+    }
+}
+
+public static class SharedFixtureOwner
+{
+    private static readonly Lazy<SharedFixture> Fixture = new();
+    private static readonly ConcurrentBag<Guid> InstanceIds = [];
+
+    public static SharedFixture Get()
+    {
+        var fixture = Fixture.Value;
+        InstanceIds.Add(fixture.InstanceId);
+        return fixture;
+    }
+
+    public static int DistinctInstances => InstanceIds.Distinct().Count();
+
+    public static void DisposeIfCreated()
+    {
+        if (Fixture.IsValueCreated)
+        {
+            Fixture.Value.Dispose();
+        }
+    }
+}
+
+[TestClass]
+public sealed class SharedFixtureFirstTests
+{
+    private static SharedFixture fixture = null!;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext context) => fixture = SharedFixtureOwner.Get();
+
+    [TestMethod]
+    public void FirstClassReceivesSharedFixture()
+    {
+        Assert.AreNotEqual(Guid.Empty, fixture.InstanceId);
+        Assert.AreEqual(1, SharedFixtureOwner.DistinctInstances);
+    }
+}
+
+[TestClass]
+public sealed class SharedFixtureSecondTests
+{
+    private static SharedFixture fixture = null!;
+
+    [ClassInitialize]
+    public static void Initialize(TestContext context) => fixture = SharedFixtureOwner.Get();
+
+    [TestMethod]
+    public void SecondClassReceivesSameFixture()
+    {
+        Assert.AreNotEqual(Guid.Empty, fixture.InstanceId);
+        Assert.AreEqual(1, SharedFixtureOwner.DistinctInstances);
+    }
+}
+
+[TestClass]
+public static class SharedFixtureCleanup
+{
+    [AssemblyCleanup]
+    public static void Cleanup() => SharedFixtureOwner.DisposeIfCreated();
+}
+
+public static class ConcurrencyProbe
+{
+    private static readonly TaskCompletionSource<bool> First =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static readonly TaskCompletionSource<bool> Second =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static async Task MeetAsync(bool first)
+    {
+        (first ? First : Second).TrySetResult(true);
+        await (first ? Second : First).Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}
+
+[TestClass]
+public sealed class ConcurrencyFirstTests
+{
+    [TestMethod]
+    public Task SeparateClassesRunConcurrently() => ConcurrencyProbe.MeetAsync(first: true);
+}
+
+[TestClass]
+public sealed class ConcurrencySecondTests
+{
+    [TestMethod]
+    public Task SeparateClassesRunConcurrently() => ConcurrencyProbe.MeetAsync(first: false);
+}

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -13,5 +13,8 @@
   <ItemGroup>
     <Compile Remove="AnalyzerProbe.cs" />
     <Compile Include="AnalyzerProbe.cs" Condition="'$(RunAnalyzerProbe)' == 'true'" />
+    <Compile Remove="TimeoutProbe.cs" />
+    <Compile Include="TimeoutProbe.cs" Condition="'$(RunTimeoutProbe)' == 'true'" />
+    <Compile Remove="FrameworkEvidenceTests.cs" Condition="'$(RunTimeoutProbe)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="MSTest.Sdk/4.3.3">
+  <PropertyGroup>
+    <TestingExtensionsProfile>Default</TestingExtensionsProfile>
+    <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Andreja.AppHost\Andreja.AppHost.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="AnalyzerProbe.cs" />
+    <Compile Include="AnalyzerProbe.cs" Condition="'$(RunAnalyzerProbe)' == 'true'" />
+  </ItemGroup>
+</Project>

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/TimeoutProbe.cs
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/TimeoutProbe.cs
@@ -1,0 +1,14 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: DoNotParallelize]
+
+namespace MSTestMtpSpike;
+
+[TestClass]
+public sealed class TimeoutProbe(TestContext testContext)
+{
+    [TestMethod]
+    [Timeout(250, CooperativeCancellation = true)]
+    public async Task TimeoutEnforcementProbe() =>
+        await Task.Delay(TimeSpan.FromSeconds(30), testContext.CancellationToken);
+}

--- a/scripts/evidence/test-platform-spike/README.md
+++ b/scripts/evidence/test-platform-spike/README.md
@@ -1,0 +1,30 @@
+# Issue 108 test-platform spike
+
+This isolated harness compares xUnit.net v3 `xunit.v3` 4.0.0 and
+`MSTest.Sdk` 4.3.3 on Microsoft.Testing.Platform 2.3.3 with the repository's
+pinned .NET SDK 10.0.301. It is excluded from `Andreja.slnx` and does not replace
+or modify the production xUnit 2 suite.
+
+The equivalent projects exercise data and a runtime-expanded row, async
+lifecycle/cleanup, class and cross-class fixtures, explicit class concurrency,
+filters, an intentional skip, cooperative timeout/cancellation, captured output,
+Andreja `WebApplicationFactory`, rejection of the fake authentication header,
+and production EF migration metadata. The MSTest fixture is lazy and class
+requested: a category-only filter proves it does not initialize for unrelated
+tests. A conditional negative analyzer probe compares always-true assertion
+diagnostics without adding that test to normal discovery.
+
+Run from the repository root:
+
+```powershell
+pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1 `
+  -Dotnet .\artifacts\dotnet\dotnet.exe
+```
+
+Omit `-Dotnet` when the pinned SDK is already installed. Results are written
+only under ignored `artifacts\test-platform-spike`.
+
+This harness makes no network or database call while executing tests. Package
+restore is the only networked step. Live disposable PostgreSQL and graphical
+Visual Studio/VS Code discovery remain separate evidence gates; do not report
+them as passed from this harness.

--- a/scripts/evidence/test-platform-spike/README.md
+++ b/scripts/evidence/test-platform-spike/README.md
@@ -7,12 +7,17 @@ or modify the production xUnit 2 suite.
 
 The equivalent projects exercise data and a runtime-expanded row, async
 lifecycle/cleanup, class and cross-class fixtures, explicit class concurrency,
-filters, an intentional skip, cooperative timeout/cancellation, captured output,
-Andreja `WebApplicationFactory`, rejection of the fake authentication header,
-and production EF migration metadata. The MSTest fixture is lazy and class
-requested: a category-only filter proves it does not initialize for unrelated
-tests. A conditional negative analyzer probe compares always-true assertion
-diagnostics without adding that test to normal discovery.
+filters, an intentional skip, captured output, Andreja `WebApplicationFactory`,
+rejection of the fake authentication header, and production EF migration
+metadata. Isolated negative timeout probes deliberately exceed 250 ms for both
+frameworks; the harness requires a nonzero runner exit, one failed TRX result
+with timeout/cancellation evidence, and kills the process after 15 seconds if
+enforcement breaks. These probes do not change normal discovery inventory.
+The MSTest fixture is lazy and class requested: a category-only filter proves it
+does not initialize for unrelated tests. A conditional negative analyzer probe
+compares always-true assertion diagnostics without adding that test to normal
+discovery. Warm runs alternate candidate order, and startup checks exercise the
+median calculation with odd and even samples before the 10% gate uses it.
 
 Run from the repository root:
 

--- a/scripts/evidence/test-platform-spike/README.md
+++ b/scripts/evidence/test-platform-spike/README.md
@@ -11,8 +11,11 @@ filters, an intentional skip, captured output, Andreja `WebApplicationFactory`,
 rejection of the fake authentication header, and production EF migration
 metadata. Isolated negative timeout probes deliberately exceed 250 ms for both
 frameworks; the harness requires a nonzero runner exit, one failed TRX result
-with timeout/cancellation evidence, and kills the process after 15 seconds if
-enforcement breaks. These probes do not change normal discovery inventory.
+whose runner-generated error message contains timeout/cancellation evidence,
+and kills the process after 15 seconds if enforcement breaks. Authored TRX
+identifiers are excluded from that assertion, and a startup regression check
+proves a test name containing `Timeout` cannot satisfy it. These probes do not
+change normal discovery inventory.
 The MSTest fixture is lazy and class requested: a category-only filter proves it
 does not initialize for unrelated tests. A conditional negative analyzer probe
 compares always-true assertion diagnostics without adding that test to normal
@@ -28,6 +31,9 @@ pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1 `
 
 Omit `-Dotnet` when the pinned SDK is already installed. Results are written
 only under ignored `artifacts\test-platform-spike`.
+
+Run only the deterministic helper checks with
+`-ValidateHelpersOnly`; this does not restore, build, or execute either spike.
 
 This harness makes no network or database call while executing tests. Package
 restore is the only networked step. Live disposable PostgreSQL and graphical

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/AnalyzerProbe.cs
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/AnalyzerProbe.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace XunitV3Spike;
+
+public sealed class AnalyzerProbe
+{
+    [Fact]
+    public void AlwaysTrueAssertion() => Assert.True(true);
+}

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/FrameworkEvidenceTests.cs
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/FrameworkEvidenceTests.cs
@@ -1,0 +1,193 @@
+using Andreja.Adapters.PostgreSql;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore.Migrations;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using Xunit;
+
+namespace XunitV3Spike;
+
+public sealed class BasicAndLifecycleTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper output;
+    private bool initialized;
+
+    public BasicAndLifecycleTests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        initialized = true;
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var path = Environment.GetEnvironmentVariable("ANDREJA_SPIKE_LIFECYCLE_FILE");
+        if (path is not null)
+        {
+            await File.WriteAllTextAsync(path, "xunit-v3-cleanup");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public void FactAndAsyncLifecyclePass()
+    {
+        output.WriteLine("xunit-v3-output");
+        Assert.True(initialized);
+    }
+
+    [Theory]
+    [InlineData(1, 2, 3)]
+    [InlineData(-1, 1, 0)]
+    [Trait("Category", "Smoke")]
+    public void InlineDataAdds(int left, int right, int expected) =>
+        Assert.Equal(expected, left + right);
+
+    public static TheoryData<Exception> RuntimeRows =>
+    [
+        new InvalidOperationException("first"),
+        new ArgumentException("second"),
+    ];
+
+    [Theory]
+    [MemberData(nameof(RuntimeRows), DisableDiscoveryEnumeration = true)]
+    public void RuntimeExpandedMemberDataIsAccountedFor(Exception exception) =>
+        Assert.NotEmpty(exception.Message);
+
+    [Fact(Skip = "intentional evidence skip")]
+    [Trait("Category", "Smoke")]
+    public void IntentionalSkipIsReported()
+    {
+    }
+
+    [Fact(Timeout = 2_000)]
+    [Trait("Category", "Smoke")]
+    public async Task TimeoutAndCancellationAreBounded()
+    {
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+    }
+}
+
+public sealed class AndrejaFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
+        builder.UseEnvironment("Development");
+}
+
+public sealed class WebApplicationFactoryTests(AndrejaFactory factory)
+    : IClassFixture<AndrejaFactory>
+{
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnonymousApiAndFakeAuthenticationHeaderStayUnauthorized()
+    {
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://localhost"),
+        });
+
+        using var anonymous = await client.GetAsync(
+            "/api/v1/open-loops/tasks",
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, anonymous.StatusCode);
+
+        client.DefaultRequestHeaders.Add("X-Andreja-Test-Authenticate", "true");
+        using var fakeHeader = await client.GetAsync(
+            "/api/v1/open-loops/tasks",
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, fakeHeader.StatusCode);
+    }
+}
+
+public sealed class EfMigrationMetadataTests
+{
+    [Fact]
+    public void ProductionEfMigrationsAreDiscoverableWithoutConnecting()
+    {
+        var migrations = typeof(AndrejaIdentityDbContext).Assembly
+            .GetTypes()
+            .Count(type => type.GetCustomAttribute<MigrationAttribute>() is not null);
+
+        Assert.Equal(6, migrations);
+    }
+}
+
+public sealed class SharedFixture : IAsyncLifetime
+{
+    public Guid InstanceId { get; } = Guid.NewGuid();
+
+    public ValueTask InitializeAsync()
+    {
+        SharedFixtureState.Record(InstanceId);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+public static class SharedFixtureState
+{
+    private static readonly ConcurrentBag<Guid> InstanceIds = [];
+
+    public static void Record(Guid instanceId) => InstanceIds.Add(instanceId);
+
+    public static int DistinctInstances => InstanceIds.Distinct().Count();
+}
+
+[CollectionDefinition("shared-resource")]
+public sealed class SharedResourceGroup : ICollectionFixture<SharedFixture>;
+
+[Collection("shared-resource")]
+public sealed class SharedFixtureFirstTests(SharedFixture fixture)
+{
+    [Fact]
+    public void FirstClassReceivesCollectionFixture()
+    {
+        Assert.NotEqual(Guid.Empty, fixture.InstanceId);
+        Assert.Equal(1, SharedFixtureState.DistinctInstances);
+    }
+}
+
+[Collection("shared-resource")]
+public sealed class SharedFixtureSecondTests(SharedFixture fixture)
+{
+    [Fact]
+    public void SecondClassReceivesSameCollectionFixture()
+    {
+        Assert.NotEqual(Guid.Empty, fixture.InstanceId);
+        Assert.Equal(1, SharedFixtureState.DistinctInstances);
+    }
+}
+
+public static class ConcurrencyProbe
+{
+    private static readonly TaskCompletionSource<bool> First =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static readonly TaskCompletionSource<bool> Second =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static async Task MeetAsync(bool first)
+    {
+        (first ? First : Second).TrySetResult(true);
+        await (first ? Second : First).Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}
+
+public sealed class ConcurrencyFirstTests
+{
+    [Fact]
+    public Task SeparateClassesRunConcurrently() => ConcurrencyProbe.MeetAsync(first: true);
+}
+
+public sealed class ConcurrencySecondTests
+{
+    [Fact]
+    public Task SeparateClassesRunConcurrently() => ConcurrencyProbe.MeetAsync(first: false);
+}

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/TimeoutProbe.cs
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/TimeoutProbe.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+namespace XunitV3Spike;
+
+public sealed class TimeoutProbe
+{
+    [Fact(Timeout = 250)]
+    public async Task TimeoutEnforcementProbe() =>
+        await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+}

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Andreja.AppHost\Andreja.AppHost.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="AnalyzerProbe.cs" />
+    <Compile Include="AnalyzerProbe.cs" Condition="'$(RunAnalyzerProbe)' == 'true'" />
+  </ItemGroup>
+</Project>

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
@@ -16,5 +16,8 @@
   <ItemGroup>
     <Compile Remove="AnalyzerProbe.cs" />
     <Compile Include="AnalyzerProbe.cs" Condition="'$(RunAnalyzerProbe)' == 'true'" />
+    <Compile Remove="TimeoutProbe.cs" />
+    <Compile Include="TimeoutProbe.cs" Condition="'$(RunTimeoutProbe)' == 'true'" />
+    <Compile Remove="FrameworkEvidenceTests.cs" Condition="'$(RunTimeoutProbe)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/scripts/evidence/test-platform-spike/global.json
+++ b/scripts/evidence/test-platform-spike/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "disable",
+    "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
Closes #108

Working as Data (Quality Engineering Lead); an earlier rejection revision was owned independently by Jett Reno (Platform/SRE and Channel Platform Lead), and the current third independent revision is owned by T'Pol (Domain/Application Lead).

## Recommendation

Retain Cyrus's recorded MSTest/Microsoft.Testing.Platform long-term direction. `MSTest.Sdk` 4.3.3/MTP 2.3.3 preserved representative evidence and did not cross the 10% sustained regression stop threshold. This does not claim a performance winner, accept Proposed ADR 0007, authorize migration, or modify the production xUnit 2 suite. Issue #112 owns migration.

## Evidence and revision

- Isolated xUnit v3 4.0.0 and MSTest/MTP projects remain outside `Andreja.slnx`.
- Debug/Release normal inventory remains stable: xUnit discovered 12 and produced 13 result rows; MSTest discovered/produced 13. Both executed/passed 12 with one intentional skip.
- Conditional negative timeout probes for both candidates deliberately exceed 250 ms. The harness requires a nonzero runner exit, exactly one failed TRX result with timeout/cancellation evidence, and kills the process tree after 15 seconds if enforcement breaks.
- Timeout/cancellation evidence is matched only in runner-generated `Output/ErrorInfo/Message` fields, not `OuterXml`, test names, or other authored identifiers. A focused synthetic regression proves an unrelated failure whose test name contains `Timeout` is rejected.
- TRX gates verify captured output and intentional skip evidence.
- Warm runs alternate candidate order. A tested mathematical median handles odd and even samples before the 10% gate uses it.
- Four counterbalanced recorded samples: xUnit 1,322 / 1,463.5 / 1,652 ms min/median/max; MSTest 1,264 / 1,319.5 / 1,551 ms. The MSTest median was 9.8% faster; no decision-grade performance winner is claimed.

## Validation

- `pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1 -ValidateHelpersOnly` — passed; the authored `Timeout` identifier regression was rejected as required.
- `pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1 -Dotnet .\artifacts\dotnet\dotnet.exe -WarmRuns 4` — passed. Both genuine timeout probes produced 1 total/1 executed/1 failed TRX result; Debug/Release inventory remained 13 total/12 executed/12 passed/1 skipped for both candidates. Current warm medians were xUnit 1,389.5 ms and MSTest/MTP 1,235 ms.
- `dotnet format <each spike project> --verify-no-changes --no-restore` — both passed.
- PowerShell parser over all 16 tracked `.ps1` files — passed. PSScriptAnalyzer was not installed locally; the hosted workflow remains authoritative for its configured rules.
- `git diff --check` — passed. Whole-PR and revision path checks confirmed no files under `tests/` changed.

Earlier package signature/advisory, documentation consistency, architecture diagram, and service-free production inventory evidence remains recorded in the issue artifact. Live PostgreSQL and graphical IDE execution remain blocked/unobserved and belong to #112.

No cloud account, subscription, free tier, trial, credential, or production authentication path was used.