### PR TITLE
Configure issue drain for five-child ACK waves

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -80,9 +80,9 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 - Use `create_session` for agents that produce commits (code, config, docs)
 - Use `task` tool for pure analysis, coordination, or read-only research
 - **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
-- **Concurrency:** Generic work may use 4-5 simultaneous sub-sessions. Issue
-  drain uses one batch of up to five child issue sessions, capped by lower
-  verified platform capacity and every safety gate.
+- **Concurrency:** Generic work may use up to five simultaneous sub-sessions.
+  Issue drain uses waves of five child issue sessions, reduced by lower verified
+  platform capacity and every safety gate.
 - **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
 - **Fallback:** Outside issue drain, a definitive `create_session` failure may
   use `task`. Issue drain permits exactly one paced local fallback only after
@@ -478,9 +478,12 @@ Never crash or halt because an MCP tool is missing. MCP tools are enhancements, 
 
 > **⚠️ Issue-drain exception:** Queue work is governed by
 > `.squad/skills/squad-issue-drain/PROMPT.md`. Universal Section 0, verified
-> atomic ownership, lower App capacity, 10-second spawn-attempt pacing,
-> correlated all-ACK batch release, and ambiguous-creation rules override eager
-> execution and generic fan-out.
+> atomic issue reservations, lower App capacity, exact 10-second spawn-attempt
+> pacing without in-turn sleep, and the all-successfully-created-child ACK
+> barrier override eager execution and generic fan-out. Launch same-wave members
+> without waiting for individual ACKs. A failed/ambiguous creation, changed
+> eligibility, lost capacity, or closed safety gate stops the remainder of that
+> wave without replacement and blocks the next wave.
 
 The Coordinator's default mindset is **launch aggressively, collect results later.**
 
@@ -516,8 +519,11 @@ Before spawning, assess: **is there a reason this MUST be sync?** If not, use ba
 
 ### Parallel Fan-Out
 
-This section governs ordinary routed work only. Issue-drain queue admission uses
-its stricter batch contract and must not launch all children in one tool turn.
+This section governs ordinary routed work only. Issue-drain queue admission
+reserves up to five issues, launches one reserved child per exact 10-second
+boundary without waiting for individual ACKs, and must not launch all children
+in one tool turn. It releases only after the spawn phase closes and every
+successfully created child returns a valid correlated ACK.
 
 When the user gives any task, the Coordinator MUST:
 
@@ -922,6 +928,16 @@ existing repository-scoped atomic lease or conditional-create/CAS capability.
 Without it, remain read-only and claim no exclusivity. If Section 0 runs
 `Retrospective with Enforcement`, use the exclusive weekly retrospective Scribe
 completion mode in this file.
+
+Ralph must follow the five-child wave ledger rather than generic simultaneous
+fan-out: reserve each issue before creation, use a one-time wake or
+`NEXT_TICK_REQUIRED` at every 10-second boundary, and do not wait for an
+individual ACK before launching the next reserved member. Any failed or
+ambiguous creation, changed eligibility, lost capacity, or closed safety gate
+stops the remaining wave. Every successfully created child remains owned and
+paused until the all-created-child ACK barrier passes. A negative, missing, or
+invalid ACK blocks the next wave; timeout/restart permits one inspection at five
+minutes and never replacement while ownership is uncertain.
 
 Ralph may classify an approved, check-passing PR as
 `READY_FOR_AGENT_MERGE`, but MUST NOT merge, auto-merge, enqueue, or activate

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -18,6 +18,15 @@ authorized by issue drain. Do not use plain `squad_state_write`, overwrite an
 existing key, retry an uncertain result, or run normal inbox/log/history
 maintenance. A conflict or unavailable capability fails closed.
 
+## Issue-drain wave evidence
+
+When a spawn manifest belongs to issue drain, preserve its wave/batch ID,
+stable admission tokens, reservations, creation outcomes, ACK dispositions, and
+release state exactly as observed. The ACK barrier covers all and only
+successfully created children. Record a stopped partial wave separately from a
+negative or invalid/corrupt ACK set. Never infer release, next-wave admission,
+or replacement from silence, a failed create, or an uncertain child.
+
 ## What I Own
 
 - `.squad/log/` — session logs (what happened, who worked, what was decided)

--- a/.squad/ralph-instructions.md
+++ b/.squad/ralph-instructions.md
@@ -18,7 +18,8 @@
     • Agent persona, tone, or verbosity for session output
 
   YOU CANNOT override via this file:
-    • Parallelism — Ralph always spawns agents for all actionable issues simultaneously
+    • Issue-drain safety — Ralph uses reserved waves of five, lower confirmed
+      capacity, exact 10-second spawn-attempt pacing, and the created-child ACK barrier
     • Core eligibility filter (squad/squad:* label required, not blocked, not assigned)
     • The underlying `gh` / Copilot CLI command used to spawn each session
 
@@ -45,12 +46,21 @@
 ## Ralph, Go!
 
 Read this file for your full instructions.  Follow ALL sections.
-MAXIMIZE PARALLELISM — spawn agents for ALL actionable issues simultaneously.
+MAXIMIZE SAFE PARALLELISM — enumerate all actionable issues, then admit them
+through `.squad/skills/squad-issue-drain/PROMPT.md`. Reserve waves of five or
+lower confirmed capacity. Launch one reserved member per exact 10-second
+boundary without sleeping and without waiting for each individual ACK.
 
 ### Issue Selection
 
 Work on every open, unblocked, unassigned issue labeled `squad` or `squad:{member}`.
 Skip issues that are assigned to a human, blocked, or marked `status:on-hold`.
+Before creating a child, atomically reserve its issue. A failed/ambiguous
+creation, changed eligibility, lost capacity, or closed safety gate stops the
+remainder of the wave. Keep every successfully created child owned and paused
+until all such children return valid ACKs. Missing, negative, or corrupt ACKs
+block the next wave; inspect once after five minutes and never replace an
+uncertain child.
 
 ### Post-Task Actions
 
@@ -65,4 +75,5 @@ After completing work on each issue:
 
 If you are blocked on an issue, comment on it explaining why, add the appropriate
 `blocked:dependency`, `blocked:evidence`, or `blocked:human` label, and move to
-the next actionable item. Do not halt the loop.
+the next actionable item only after the current wave's stop and ACK state is
+reconciled. Do not continue launching the remainder of a stopped wave.

--- a/.squad/skills/squad-issue-drain/PROMPT.md
+++ b/.squad/skills/squad-issue-drain/PROMPT.md
@@ -1,6 +1,6 @@
 # Squad Issue Drain MVP Prompt
 
-**PROMPT_VERSION:** `squad-issue-drain/0.3.0`
+**PROMPT_VERSION:** `squad-issue-drain/0.4.0`
 
 You are the backlog orchestrator for a GitHub repository. Work continuously
 through ready issues by coordinating local and cloud child sessions.
@@ -27,10 +27,10 @@ branch_refresh_hours: 3
 progress_report_minutes: 15
 ```
 
-Respect lower verified platform limits. A batch contains up to five child
-issue sessions and may be smaller. Never infer App capacity from the configured
+Respect lower verified platform limits. A wave contains up to five child issue
+sessions and may be smaller. Never infer App capacity from the configured
 maximum, prior success, or the existence of `create_session`. Capacity, safety
-gates, and independent file ownership all cap the batch.
+gates, and independent file ownership all cap the wave.
 
 ## 0. Universal queue admission gate
 
@@ -107,7 +107,7 @@ create a second log for a cycle. Follow
   validation pass.
 - Never hide failing validation or describe untested work as ready.
 - Never run `gh pr merge`, enable auto-merge, or enqueue a PR.
-- Agent Merge drives the PR to merge-ready; the app performs the merge.
+- Report `READY_FOR_AGENT_MERGE`; Agent Merge and the app own landing.
 - Archive sessions and remove worktrees only after GitHub confirms the PR merged.
 - Do not place secrets, personal data, connector content, prompts, or private
   diagnostics in issues, PRs, logs, or committed Squad state.
@@ -169,7 +169,7 @@ If cloud creation definitively fails and no cloud session or branch was created,
 wait for the normal spawn gate, then try local once. If the cloud outcome is
 uncertain, mark the issue `AMBIGUOUS` and do not create a local duplicate.
 
-## 3. Admit one ACK-gated batch
+## 3. Admit one five-child ACK-gated wave
 
 Maintain a session-local ledger:
 
@@ -177,11 +177,18 @@ Maintain a session-local ledger:
 issue | child session | location | branch/worktree | PR | state | last update
 ```
 
-Build one batch of at most five independent `READY` issues, capped by lower
-verified App capacity and every safety gate. Allocate a stable batch ID and one
-stable admission token per issue before the first spawn attempt. Children start
-paused: no child may edit, commit, push, open a PR, or mutate state until the
-coordinator validates every ACK in the batch and releases the whole batch.
+Build one wave of at most five independent `READY` issues, capped by lower
+verified App capacity and every safety gate. Allocate a stable wave/batch ID and
+one stable admission token per issue. Before any child creation, reserve every
+selected issue under the verified repository-scoped atomic owner and record the
+reservation in the ledger. A candidate without a current unique reservation is
+not part of the wave and must not be created.
+
+Every successfully created child starts paused. Launch the next reserved member
+of the same wave without waiting for the preceding child's ACK. Do not release a
+child after its individual ACK. The spawn phase must first complete or stop, and
+then every successfully created child must return a valid correlated ACK before
+any created child is released or another wave can begin.
 
 Before each spawn attempt:
 
@@ -193,11 +200,21 @@ Before each spawn attempt:
 4. Confirm no session, branch, worktree, or PR already owns it.
 5. Confirm the issue does not collide with active writers.
 6. Confirm lower verified capacity still exists.
-7. Confirm at least 10 seconds elapsed since the prior spawn attempt, including
-   failed attempts and a local fallback attempt.
-8. Create exactly one child session with the preallocated admission token.
-9. Record the exact creation outcome. An uncertain outcome is `AMBIGUOUS` and
-   blocks replacement.
+7. Confirm the issue still has its unique wave reservation.
+8. At the exact 10-second boundary after the prior spawn attempt, including a
+   failed attempt or local fallback attempt, create exactly one child session
+   with the preallocated admission token. A delayed wake may attempt immediately
+   but must never burst or shorten the interval.
+9. Record the attempt timestamp and exact creation outcome before any further
+   launch decision.
+
+If creation is ambiguous, definitively fails, eligibility changes, capacity is
+lost, or any safety gate closes, immediately stop launching the remainder of
+the wave. Record the current disposition and mark later reservations unlaunched;
+do not create a replacement. Keep every successfully created child owned,
+paused, and awaiting its ACK. A definitively failed cloud creation may use its
+single same-token local fallback after the next 10-second boundary, but no other
+wave member may launch after the stop.
 
 The child ACK must include:
 
@@ -219,18 +236,28 @@ blocker=<none or reason>
 Validate exact correlation against the batch ledger: issue, batch, admission
 token, session, location, branch/workspace, and base must match. `ready` must be
 the literal boolean `true`; both checks must equal `clear`; blocker must equal
-`none`. Unknown, duplicate, mismatched, blocked, or extra ACKs invalidate the
-batch.
+`none`. Unknown, duplicate, mismatched, or extra ACKs are invalid/corrupt. A correlated
+ACK with `ready: false`, a non-clear check, or a blocker is a negative ACK.
+Either disposition keeps all created children paused and blocks the next wave.
 
-Continue paced spawn attempts until the capped batch is created or a safety gate
-blocks. Do not release any child after an individual ACK. Require an explicit
-valid ACK from every admitted child, then release the entire batch and only then
-advance. A missing ACK keeps every child paused. At five minutes, reconcile
-sessions, branches, worktrees, PRs, and messages once; do not replace the child
+The barrier covers all and only successfully created children; failed,
+ambiguous, ineligible, and unlaunched reservations do not manufacture ACKs.
+Require an explicit valid ACK from every successfully created child. A normally
+completed wave may then release all created children and advance. A stopped
+partial wave with all created-child ACKs valid may release those children, but
+remains distinctly stopped and cannot begin another wave until its stop reason
+is reconciled and Section 0 plus a full rescan permits a new admission. A
+stopped wave with no created children never advances by a vacuous ACK set.
+
+Derive the five-minute deadline from the recorded wave-close timestamp; callers
+must not extend it. At timeout or restart, inspect sessions, branches, worktrees,
+PRs, and messages exactly once and record that inspection. A missing ACK remains
+blocking after inspection. Never replace a missing, failed, or uncertain child
 while creation or ownership is uncertain.
 
-Do not sleep inside a turn. If 10 seconds have not elapsed, schedule a supported
-one-time wake or end with `NEXT_TICK_REQUIRED`.
+Do not sleep inside a turn. At every 10-second boundary, schedule a supported
+one-time wake or end with `NEXT_TICK_REQUIRED`. No loop, polling call, or prose
+instruction substitutes for the wake/tick boundary.
 
 If cloud creation definitively proves that no session, branch, worktree, or PR
 was created, retain the same admission token, advance the global spawn-attempt
@@ -258,8 +285,8 @@ and exact-base preflight; then send the required ACK containing this exact batch
 ID and admission token. STOP. Do not edit domain files, commit, push, open a PR,
 mutate runtime state, or begin implementation until the coordinator sends an
 explicit RELEASE containing the same batch ID and admission token. A release is
-valid only after every admitted child ACKs. If no correlated release arrives,
-remain paused.
+valid only after the spawn phase closes and every successfully created child
+ACKs. If no correlated release arrives, remain paused.
 
 AFTER CORRELATED RELEASE:
 Work only in your assigned issue workspace and branch.
@@ -304,8 +331,8 @@ On each tick:
 7. Remove only clean worktrees with no unique or unpushed commits.
 8. Rescan the backlog and fill safe capacity.
 
-If Agent Merge activation is unavailable, report `READY_FOR_AGENT_MERGE` and
-leave the branch and session intact.
+Report `READY_FOR_AGENT_MERGE` and leave the branch and session intact. Do not
+activate Agent Merge; Agent Merge and the app own landing.
 
 ## 6. Report progress
 
@@ -322,7 +349,7 @@ Use:
 
 ```text
 Backlog: ready N | active N | blocked N | ambiguous N
-Capacity: useful N/6 target | App children N/<confirmed cap>
+Capacity: useful N/5 target | App children N/<confirmed cap>
 Started: #N location owner
 Drafts: #N -> PR
 Merge-ready: PRs
@@ -335,7 +362,8 @@ Next action: action or NEXT_TICK_REQUIRED
 Repeat:
 
 ```text
-Section 0 -> scan -> classify -> pace batch spawns -> all ACKs -> release batch
+Section 0 -> scan -> classify -> reserve wave -> pace wave spawns
+-> all successfully created child ACKs -> release eligible created children
 -> monitor -> report -> Section 0 -> rescan
 ```
 

--- a/.squad/skills/squad-issue-drain/SKILL.md
+++ b/.squad/skills/squad-issue-drain/SKILL.md
@@ -11,12 +11,16 @@ Start with the fail-closed defaults:
 
 - writer operation only with verified existing repository-scoped atomic
   ownership; otherwise read-only;
-- up to five App child issue sessions per batch, capped by lower verified
+- waves of up to five App child issue sessions, capped by lower verified
   capacity;
 - one issue, owner, session, branch/worktree, and PR;
-- at least 10 seconds between all spawn attempts;
-- require a correlated valid ACK from every admitted child before releasing any
-  child or advancing the batch;
+- reserve each selected issue before creation and wait exactly 10 seconds
+  between all spawn attempts without sleeping inside a turn;
+- continue same-wave launches without waiting for individual ACKs, then require
+  a correlated valid ACK from every successfully created child before release
+  or another wave;
+- stop a partial wave on failed/ambiguous creation, changed eligibility, lost
+  capacity, or a closed safety gate, without replacing uncertain children;
 - prefer eligible cloud work and fall back locally only after definitive
   non-creation;
 - use Squad as the child agent when supported;

--- a/.squad/skills/squad-issue-drain/issue-drain.js
+++ b/.squad/skills/squad-issue-drain/issue-drain.js
@@ -11,8 +11,26 @@ const QUEUE_OPERATIONS = new Set([
 ]);
 
 function validDate(value) {
-  const timestamp = typeof value === 'string' ? Date.parse(value) : NaN;
-  return Number.isFinite(timestamp) ? timestamp : null;
+  if (typeof value !== 'string') return null;
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|[+-]\d{2}:\d{2})$/,
+  );
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, second, fraction = '', zone] = match;
+  const wall = `${year}-${month}-${day}T${hour}:${minute}:${second}.${fraction.padEnd(3, '0')}Z`;
+  const wallTimestamp = Date.parse(wall);
+  if (!Number.isFinite(wallTimestamp)
+      || new Date(wallTimestamp).toISOString() !== wall) {
+    return null;
+  }
+  if (zone === 'Z') return wallTimestamp;
+
+  const sign = zone[0] === '+' ? 1 : -1;
+  const offsetHour = Number(zone.slice(1, 3));
+  const offsetMinute = Number(zone.slice(4, 6));
+  if (offsetHour > 23 || offsetMinute > 59) return null;
+  return wallTimestamp - sign * ((offsetHour * 60) + offsetMinute) * 60_000;
 }
 
 function positiveInteger(value) {
@@ -180,14 +198,28 @@ function createBatch({
     return { ready: false, reason: 'candidate-correlation-duplicate', batch: null };
   }
 
+  const reservedAt = new Date(validDate(now)).toISOString();
   return {
     ready: true,
-    reason: 'batch-ready',
+    reason: 'wave-reserved',
     batch: {
       id: batchId,
       limit,
       authorization: { ...sectionZero.authorization },
-      admissions: selected.map((candidate) => ({ ...candidate, batchId })),
+      launchState: 'launching',
+      reservedAt,
+      launchClosedAt: null,
+      stopReason: null,
+      ackInspectionAt: null,
+      admissions: selected.map((candidate) => ({
+        ...candidate,
+        batchId,
+        reservationId: candidate.admissionToken,
+        state: 'reserved',
+        reservedAt,
+        attemptedAt: null,
+        createdAt: null,
+      })),
     },
   };
 }
@@ -197,8 +229,11 @@ function assessSpawnAttempt({
   previousAttemptAt = null,
   sectionZero,
   batchId,
+  admission,
   duplicateCheck = false,
   collisionCheck = false,
+  issueReady = false,
+  capacityAvailable = false,
   creationOutcome = 'not-started',
 }) {
   if (!writerAuthorizationCurrent(sectionZero, now, batchId)) {
@@ -209,6 +244,20 @@ function assessSpawnAttempt({
   }
   if (collisionCheck !== true) {
     return { allowed: false, reason: 'collision-check-incomplete' };
+  }
+  if (issueReady !== true) {
+    return { allowed: false, reason: 'issue-eligibility-changed' };
+  }
+  if (capacityAvailable !== true) {
+    return { allowed: false, reason: 'verified-capacity-unavailable' };
+  }
+  if (!admission
+      || admission.batchId !== batchId
+      || admission.state !== 'reserved'
+      || admission.reservationId !== admission.admissionToken
+      || typeof admission.admissionToken !== 'string'
+      || !admission.admissionToken) {
+    return { allowed: false, reason: 'issue-reservation-invalid' };
   }
   if (!['not-started', 'definitive-non-creation'].includes(creationOutcome)) {
     return { allowed: false, reason: 'creation-outcome-ambiguous' };
@@ -223,15 +272,139 @@ function assessSpawnAttempt({
     return {
       allowed: false,
       reason: 'spawn-spacing-not-elapsed',
-      retryAt: new Date(previous + MIN_SPAWN_SPACING_MILLISECONDS).toISOString(),
+      wakeAt: new Date(previous + MIN_SPAWN_SPACING_MILLISECONDS).toISOString(),
+      nextAction: 'ONE_TIME_WAKE_OR_NEXT_TICK_REQUIRED',
     };
   }
-  return { allowed: true, reason: 'spawn-attempt-authorized' };
+  return {
+    allowed: true,
+    reason: 'spawn-attempt-authorized',
+    batchId,
+    admissionToken: admission.admissionToken,
+    attemptedAt: new Date(current).toISOString(),
+    previousAttemptAt: previous === null ? null : new Date(previous).toISOString(),
+  };
+}
+
+function recordCreationOutcome({
+  batch,
+  admissionToken,
+  outcome,
+  attemptedAt,
+  child = {},
+  fallback = false,
+}) {
+  const attempt = validDate(attemptedAt);
+  if (!batch || !Array.isArray(batch.admissions) || attempt === null) {
+    return { recorded: false, reason: 'wave-or-attempt-invalid', batch: null };
+  }
+  const index = batch.admissions.findIndex(
+    (admission) => admission.admissionToken === admissionToken,
+  );
+  if (index < 0) {
+    return { recorded: false, reason: 'reservation-not-found', batch: null };
+  }
+
+  const current = batch.admissions[index];
+  const stateAllowed = current.state === 'reserved'
+    || (fallback === true && current.state === 'failed');
+  if (!stateAllowed) {
+    return { recorded: false, reason: 'reservation-already-resolved', batch: null };
+  }
+  const supported = new Set([
+    'created',
+    'definitive-non-creation',
+    'uncertain',
+    'eligibility-changed',
+    'capacity-lost',
+    'safety-gate-failed',
+  ]);
+  if (!supported.has(outcome)) {
+    return { recorded: false, reason: 'creation-outcome-invalid', batch: null };
+  }
+  const reserved = validDate(current.reservedAt);
+  if (reserved === null || attempt < reserved) {
+    return { recorded: false, reason: 'attempt-precedes-reservation', batch: null };
+  }
+  if (['created', 'definitive-non-creation', 'uncertain'].includes(outcome)) {
+    const previousAttempts = batch.admissions
+      .map((item) => validDate(item.attemptedAt))
+      .filter((timestamp) => timestamp !== null);
+    const previousAttempt = previousAttempts.length === 0
+      ? null
+      : Math.max(...previousAttempts);
+    if (previousAttempt !== null
+        && attempt - previousAttempt < MIN_SPAWN_SPACING_MILLISECONDS) {
+      return { recorded: false, reason: 'attempt-spacing-invalid', batch: null };
+    }
+  }
+
+  const next = {
+    ...batch,
+    admissions: batch.admissions.map((admission) => ({ ...admission })),
+  };
+  const admission = next.admissions[index];
+  admission.attemptedAt = new Date(attempt).toISOString();
+
+  if (outcome === 'created') {
+    const required = ['session', 'location', 'branch', 'workspace', 'base'];
+    if (required.some((field) => typeof child[field] !== 'string' || !child[field])) {
+      return { recorded: false, reason: 'created-child-identity-invalid', batch: null };
+    }
+    Object.assign(admission, child, {
+      state: 'created',
+      createdAt: admission.attemptedAt,
+    });
+    if (next.launchState !== 'stopped'
+        && next.admissions.every((item) => item.state !== 'reserved')) {
+      next.launchState = 'complete';
+      next.launchClosedAt = admission.attemptedAt;
+    }
+    return { recorded: true, reason: 'child-created', batch: next };
+  }
+
+  const stateByOutcome = {
+    'definitive-non-creation': 'failed',
+    uncertain: 'ambiguous',
+    'eligibility-changed': 'ineligible',
+    'capacity-lost': 'unlaunched',
+    'safety-gate-failed': 'unlaunched',
+  };
+  admission.state = stateByOutcome[outcome];
+  for (let remaining = index + 1; remaining < next.admissions.length; remaining += 1) {
+    if (next.admissions[remaining].state === 'reserved') {
+      next.admissions[remaining].state = 'unlaunched';
+    }
+  }
+  next.launchState = 'stopped';
+  next.launchClosedAt = admission.attemptedAt;
+  next.stopReason = outcome;
+  return { recorded: true, reason: 'wave-stopped', batch: next };
+}
+
+function recordAckInspection({ batch, inspectedAt }) {
+  const inspected = validDate(inspectedAt);
+  const launchClosed = validDate(batch?.launchClosedAt);
+  if (!batch || inspected === null || launchClosed === null || inspected < launchClosed) {
+    return { recorded: false, reason: 'ack-inspection-invalid', batch: null };
+  }
+  if (batch.ackInspectionAt !== null) {
+    return { recorded: false, reason: 'ack-inspection-already-recorded', batch: null };
+  }
+  return {
+    recorded: true,
+    reason: 'ack-inspection-recorded',
+    batch: {
+      ...batch,
+      admissions: batch.admissions.map((admission) => ({ ...admission })),
+      ackInspectionAt: new Date(inspected).toISOString(),
+    },
+  };
 }
 
 function validateAck(expected, ack) {
   if (!expected || !ack || typeof ack !== 'object' || Array.isArray(ack)) {
-    return { valid: false, reason: 'ack-missing' };
+    return { valid: false, kind: 'invalid', reason: 'ack-missing' };
   }
   const exactFields = [
     'issue',
@@ -246,31 +419,36 @@ function validateAck(expected, ack) {
   const mismatch = exactFields.find((field) =>
     expected[field] === undefined || ack[field] !== expected[field]);
   if (mismatch) {
-    return { valid: false, reason: `ack-correlation-mismatch:${mismatch}` };
+    return {
+      valid: false,
+      kind: 'invalid',
+      reason: `ack-correlation-mismatch:${mismatch}`,
+    };
   }
   if (ack.duplicate_check !== 'clear') {
-    return { valid: false, reason: 'ack-duplicate-check-not-clear' };
+    return { valid: false, kind: 'negative', reason: 'ack-duplicate-check-not-clear' };
   }
   if (ack.collision_check !== 'clear') {
-    return { valid: false, reason: 'ack-collision-check-not-clear' };
+    return { valid: false, kind: 'negative', reason: 'ack-collision-check-not-clear' };
+  }
+  if (typeof ack.ready !== 'boolean') {
+    return { valid: false, kind: 'invalid', reason: 'ack-ready-invalid' };
   }
   if (ack.ready !== true) {
-    return { valid: false, reason: 'ack-not-ready' };
+    return { valid: false, kind: 'negative', reason: 'ack-not-ready' };
   }
   if (ack.blocker !== 'none') {
-    return { valid: false, reason: 'ack-blocked' };
+    return { valid: false, kind: 'negative', reason: 'ack-blocked' };
   }
-  return { valid: true, reason: 'ack-valid' };
+  return { valid: true, kind: 'valid', reason: 'ack-valid' };
 }
 
 function assessBatchAdvance({
   batch,
   acknowledgements = [],
   now,
-  ackDeadline,
   sectionZero,
   restarted = false,
-  reconciliationComplete = false,
 }) {
   if (!writerAuthorizationCurrent(sectionZero, now, batch?.id || null)) {
     return {
@@ -283,9 +461,9 @@ function assessBatchAdvance({
     return { allowed: false, releaseChildren: false, reason: 'batch-invalid' };
   }
   const current = validDate(now);
-  const deadline = validDate(ackDeadline);
-  if (current === null || deadline === null) {
-    return { allowed: false, releaseChildren: false, reason: 'ack-deadline-invalid' };
+  const launchClosedAt = validDate(batch.launchClosedAt);
+  if (current === null) {
+    return { allowed: false, releaseChildren: false, reason: 'ack-timestamp-invalid' };
   }
   const batchIdValid =
     typeof batch.id === 'string'
@@ -312,27 +490,18 @@ function assessBatchAdvance({
       reason: 'batch-authorization-stale-or-mismatched',
     };
   }
-  if ((restarted === true || current >= deadline) && reconciliationComplete !== true) {
-    return {
-      allowed: false,
-      releaseChildren: false,
-      reason: current >= deadline
-        ? 'ack-timeout-reconcile-required'
-        : 'restart-reconcile-required',
-    };
-  }
-
+  const created = batch.admissions.filter((admission) => admission.state === 'created');
   const ackByToken = new Map();
   for (const ack of acknowledgements) {
     if (!ack || typeof ack.admissionToken !== 'string'
         || ackByToken.has(ack.admissionToken)) {
-      return { allowed: false, releaseChildren: false, reason: 'ack-set-ambiguous' };
+      return { allowed: false, releaseChildren: false, reason: 'wave-ack-invalid' };
     }
     ackByToken.set(ack.admissionToken, ack);
   }
 
   const missing = [];
-  for (const admission of batch.admissions) {
+  for (const admission of created) {
     const ack = ackByToken.get(admission.admissionToken);
     if (!ack) {
       missing.push(admission.admissionToken);
@@ -343,31 +512,100 @@ function assessBatchAdvance({
       return {
         allowed: false,
         releaseChildren: false,
-        reason: 'batch-ack-invalid',
+        beginNextWave: false,
+        reason: validation.kind === 'negative'
+          ? 'wave-ack-negative'
+          : 'wave-ack-invalid',
         token: admission.admissionToken,
         detail: validation.reason,
       };
     }
   }
 
+  const createdTokens = new Set(created.map((admission) => admission.admissionToken));
+  if ([...ackByToken.keys()].some((token) => !createdTokens.has(token))) {
+    return {
+      allowed: false,
+      releaseChildren: false,
+      beginNextWave: false,
+      reason: 'wave-ack-invalid',
+    };
+  }
+  if (!['complete', 'stopped'].includes(batch.launchState)
+      || launchClosedAt === null) {
+    return {
+      allowed: false,
+      releaseChildren: false,
+      beginNextWave: false,
+      reason: 'wave-launch-incomplete',
+    };
+  }
+
+  const inspection = validDate(batch.ackInspectionAt);
+  if (batch.ackInspectionAt !== null
+      && (inspection === null || inspection < launchClosedAt || inspection > current)) {
+    return {
+      allowed: false,
+      releaseChildren: false,
+      beginNextWave: false,
+      reason: 'ack-inspection-invalid',
+    };
+  }
+  const inspectionRequired = restarted === true
+    || current >= launchClosedAt + ACK_TIMEOUT_MILLISECONDS;
+  if (inspectionRequired && inspection === null) {
+    return {
+      allowed: false,
+      releaseChildren: false,
+      beginNextWave: false,
+      replaceChildren: false,
+      inspectOnce: true,
+      reason: restarted === true
+        ? 'restart-inspect-required'
+        : 'ack-timeout-inspect-required',
+    };
+  }
+
   if (missing.length > 0) {
     return {
       allowed: false,
       releaseChildren: false,
-      reason: 'batch-acks-pending',
+      beginNextWave: false,
+      replaceChildren: false,
+      inspectOnce: false,
+      reason: inspection === null
+        ? 'wave-acks-pending'
+        : 'wave-acks-pending-after-inspection',
       missing,
     };
   }
-  if (ackByToken.size !== batch.admissions.length) {
-    return { allowed: false, releaseChildren: false, reason: 'ack-set-ambiguous' };
+
+  if (batch.launchState === 'stopped') {
+    return {
+      allowed: false,
+      releaseChildren: created.length > 0,
+      beginNextWave: false,
+      replaceChildren: false,
+      reason: created.length > 0
+        ? 'stopped-partial-wave-acks-valid'
+        : 'stopped-wave-no-created-children',
+      stopReason: batch.stopReason,
+    };
   }
 
-  return { allowed: true, releaseChildren: true, reason: 'all-batch-acks-valid' };
+  return {
+    allowed: true,
+    releaseChildren: true,
+    beginNextWave: true,
+    reason: 'all-created-child-acks-valid',
+  };
 }
 
 function assessLocalFallback({
   admissionToken,
   originalAdmissionToken,
+  batchId,
+  cloudAttemptAt,
   cloudOutcome,
   localFallbackAttempts = 0,
   spawnAttempt,
@@ -386,6 +624,15 @@ function assessLocalFallback({
   }
   if (!spawnAttempt || spawnAttempt.allowed !== true) {
     return { allowed: false, reason: spawnAttempt?.reason || 'spawn-attempt-not-authorized' };
+  }
+  const cloudAttempt = validDate(cloudAttemptAt);
+  if (typeof batchId !== 'string'
+      || !batchId
+      || cloudAttempt === null
+      || spawnAttempt.batchId !== batchId
+      || spawnAttempt.admissionToken !== admissionToken
+      || spawnAttempt.previousAttemptAt !== new Date(cloudAttempt).toISOString()) {
+    return { allowed: false, reason: 'fallback-attempt-correlation-invalid' };
   }
   return { allowed: true, reason: 'single-local-fallback-authorized' };
 }
@@ -408,5 +655,7 @@ module.exports = {
   assessSpawnAttempt,
   createBatch,
   mergeDisposition,
+  recordAckInspection,
+  recordCreationOutcome,
   validateAck,
 };

--- a/.squad/skills/squad-issue-drain/issue-drain.test.js
+++ b/.squad/skills/squad-issue-drain/issue-drain.test.js
@@ -15,6 +15,8 @@ const {
   assessSpawnAttempt,
   createBatch,
   mergeDisposition,
+  recordAckInspection,
+  recordCreationOutcome,
   validateAck,
 } = require('./issue-drain');
 
@@ -25,7 +27,7 @@ const writerCapability = {
   repository: 'Jamula/Andreja',
   ownerId: 'coordinator-1',
   grantId: 'grant-1',
-  verifiedAt: now,
+  verifiedAt: '2026-08-29T18:00:00.000Z',
   validUntil: '2026-08-29T20:00:00.000Z',
   kind: 'conditional-create',
   tool: 'runtime.conditionalCreate',
@@ -73,6 +75,58 @@ function ackFor(expected, override = {}) {
     blocker: 'none',
     ...override,
   };
+}
+
+function reserveBatch(
+  issues = [1, 2],
+  batchId = 'batch-1',
+  verifiedCapacity = 5,
+  reservedAt = '2026-08-29T18:59:00.000Z',
+) {
+  const result = createBatch({
+    batchId,
+    candidates: issues.map(admission),
+    verifiedCapacity,
+    sectionZero: writerSection('admit', reservedAt, batchId),
+    now: reservedAt,
+  });
+  assert.equal(result.ready, true);
+  return result.batch;
+}
+
+function recordCreated(batch, admissionToken, attemptedAt = now, fallback = false) {
+  const expected = batch.admissions.find(
+    (item) => item.admissionToken === admissionToken,
+  );
+  const result = recordCreationOutcome({
+    batch,
+    admissionToken,
+    attemptedAt,
+    fallback,
+    outcome: 'created',
+    child: {
+      session: expected.session,
+      location: expected.location,
+      branch: expected.branch,
+      workspace: expected.workspace,
+      base: expected.base,
+    },
+  });
+  assert.equal(result.recorded, true);
+  return result.batch;
+}
+
+function closeCreatedWave(batch, attemptedAt = now) {
+  const finalAttempt = Date.parse(attemptedAt);
+  return batch.admissions.reduce((current, item, index) => {
+    const milliseconds = finalAttempt
+      - ((batch.admissions.length - index - 1) * MIN_SPAWN_SPACING_MILLISECONDS);
+    return recordCreated(
+      current,
+      item.admissionToken,
+      new Date(milliseconds).toISOString(),
+    );
+  }, batch);
 }
 
 test('atomic ownership must be explicit, scoped, current, and verified', () => {
@@ -148,7 +202,13 @@ test('batch size is five and lower verified capacity overrides it', () => {
     now,
   });
   assert.equal(MAX_BATCH_SIZE, 5);
+  assert.equal(full.reason, 'wave-reserved');
   assert.equal(full.batch.admissions.length, 5);
+  assert.equal(full.batch.launchState, 'launching');
+  assert.ok(full.batch.admissions.every(
+    (item) => item.state === 'reserved'
+      && item.reservationId === item.admissionToken,
+  ));
 
   const lower = createBatch({
     batchId: 'batch-2',
@@ -162,23 +222,48 @@ test('batch size is five and lower verified capacity overrides it', () => {
 });
 
 test('spawn attempts require ten elapsed seconds and all safety checks', () => {
+  const batch = reserveBatch([1]);
   const base = {
     now,
     previousAttemptAt: '2026-08-29T18:59:50.001Z',
     sectionZero: writerSection(),
     batchId: 'batch-1',
+    admission: batch.admissions[0],
     duplicateCheck: true,
     collisionCheck: true,
+    issueReady: true,
+    capacityAvailable: true,
   };
   assert.equal(MIN_SPAWN_SPACING_MILLISECONDS, 10_000);
   assert.equal(ACK_TIMEOUT_MILLISECONDS, 300_000);
-  assert.equal(assessSpawnAttempt(base).reason, 'spawn-spacing-not-elapsed');
-  assert.equal(assessSpawnAttempt({
+  const waiting = assessSpawnAttempt(base);
+  assert.equal(waiting.reason, 'spawn-spacing-not-elapsed');
+  assert.equal(waiting.wakeAt, '2026-08-29T19:00:00.001Z');
+  assert.equal(waiting.nextAction, 'ONE_TIME_WAKE_OR_NEXT_TICK_REQUIRED');
+  const allowed = assessSpawnAttempt({
     ...base,
     previousAttemptAt: '2026-08-29T18:59:50.000Z',
-  }).allowed, true);
+  });
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.admissionToken, batch.admissions[0].admissionToken);
+  assert.equal(allowed.attemptedAt, now);
   assert.equal(assessSpawnAttempt({ ...base, duplicateCheck: false }).allowed, false);
   assert.equal(assessSpawnAttempt({ ...base, collisionCheck: false }).allowed, false);
+  assert.equal(
+    assessSpawnAttempt({ ...base, issueReady: false }).reason,
+    'issue-eligibility-changed',
+  );
+  assert.equal(
+    assessSpawnAttempt({ ...base, capacityAvailable: false }).reason,
+    'verified-capacity-unavailable',
+  );
+  assert.equal(
+    assessSpawnAttempt({
+      ...base,
+      admission: { ...base.admission, state: 'created' },
+    }).reason,
+    'issue-reservation-invalid',
+  );
 });
 
 test('ACKs are correlated to issue, admission token, ownership, and base', () => {
@@ -191,91 +276,238 @@ test('ACKs are correlated to issue, admission token, ownership, and base', () =>
     { session: 'other' },
     { branch: 'other' },
     { base: 'origin/main@changed' },
-    { duplicate_check: 'unknown' },
-    { collision_check: 'unknown' },
     { ready: 'true' },
+  ]) {
+    const result = validateAck(expected, ackFor(expected, override));
+    assert.equal(result.valid, false);
+    assert.equal(result.kind, 'invalid');
+  }
+  for (const override of [
+    { duplicate_check: 'blocked' },
+    { collision_check: 'blocked' },
+    { ready: false },
     { blocker: 'waiting' },
   ]) {
-    assert.equal(validateAck(expected, ackFor(expected, override)).valid, false);
+    const result = validateAck(expected, ackFor(expected, override));
+    assert.equal(result.valid, false);
+    assert.equal(result.kind, 'negative');
   }
 });
 
-test('every child ACK is required before child release or batch advancement', () => {
-  const batch = {
-    id: 'batch-1',
-    authorization: writerSection().authorization,
-    admissions: [admission(1), admission(2), admission(3)],
-  };
+test('same-wave spawning continues without waiting for individual ACKs', () => {
+  let batch = reserveBatch([1, 2]);
+  batch = recordCreated(
+    batch,
+    batch.admissions[0].admissionToken,
+    '2026-08-29T18:59:50.000Z',
+  );
+  const firstAck = ackFor(batch.admissions[0]);
+  const advancement = assessBatchAdvance({
+    batch,
+    acknowledgements: [firstAck],
+    now,
+    sectionZero: writerSection(),
+  });
+  assert.equal(advancement.reason, 'wave-launch-incomplete');
+  assert.equal(advancement.releaseChildren, false);
+  assert.equal(assessSpawnAttempt({
+    now,
+    previousAttemptAt: '2026-08-29T18:59:50.000Z',
+    sectionZero: writerSection(),
+    batchId: batch.id,
+    admission: batch.admissions[1],
+    duplicateCheck: true,
+    collisionCheck: true,
+    issueReady: true,
+    capacityAvailable: true,
+  }).allowed, true);
+});
+
+test('every successfully created child ACK is required before wave advancement', () => {
+  const batch = closeCreatedWave(reserveBatch([1, 2, 3]));
   const pending = assessBatchAdvance({
     batch,
     acknowledgements: batch.admissions.slice(0, 2).map(ackFor),
     now,
-    ackDeadline: '2026-08-29T19:05:00.000Z',
     sectionZero: writerSection(),
   });
   assert.equal(pending.allowed, false);
   assert.equal(pending.releaseChildren, false);
-  assert.equal(pending.reason, 'batch-acks-pending');
+  assert.equal(pending.beginNextWave, false);
+  assert.equal(pending.reason, 'wave-acks-pending');
 
   const complete = assessBatchAdvance({
     batch,
     acknowledgements: batch.admissions.map(ackFor),
     now,
-    ackDeadline: '2026-08-29T19:05:00.000Z',
     sectionZero: writerSection(),
   });
   assert.equal(complete.allowed, true);
   assert.equal(complete.releaseChildren, true);
+  assert.equal(complete.beginNextWave, true);
+  assert.equal(complete.reason, 'all-created-child-acks-valid');
 });
 
-test('restart and ACK timeout require reconciliation rather than replacement', () => {
-  const batch = {
-    id: 'batch-1',
-    authorization: writerSection().authorization,
-    admissions: [admission(1), admission(2)],
-  };
-  const restarted = JSON.parse(JSON.stringify(batch));
-  const result = assessBatchAdvance({
-    batch: restarted,
-    acknowledgements: [ackFor(restarted.admissions[0])],
-    now: '2026-08-29T19:05:00.000Z',
-    ackDeadline: '2026-08-29T19:05:00.000Z',
-    sectionZero: writerSection('admit', '2026-08-29T19:05:00.000Z'),
-    restarted: true,
-  });
-  assert.equal(result.allowed, false);
-  assert.equal(result.releaseChildren, false);
-  assert.equal(result.reason, 'ack-timeout-reconcile-required');
+test('failed, ambiguous, or ineligible creation stops the remainder of a wave', () => {
+  for (const outcome of [
+    'definitive-non-creation',
+    'uncertain',
+    'eligibility-changed',
+    'capacity-lost',
+    'safety-gate-failed',
+  ]) {
+    let batch = reserveBatch([1, 2, 3]);
+    batch = recordCreated(
+      batch,
+      batch.admissions[0].admissionToken,
+      '2026-08-29T18:59:50.000Z',
+    );
+    const stopped = recordCreationOutcome({
+      batch,
+      admissionToken: batch.admissions[1].admissionToken,
+      outcome,
+      attemptedAt: now,
+    });
+    assert.equal(stopped.recorded, true);
+    assert.equal(stopped.reason, 'wave-stopped');
+    assert.equal(stopped.batch.launchState, 'stopped');
+    assert.equal(stopped.batch.stopReason, outcome);
+    assert.equal(stopped.batch.admissions[0].state, 'created');
+    assert.equal(stopped.batch.admissions[2].state, 'unlaunched');
 
-  const allAcks = restarted.admissions.map(ackFor);
+    const barrier = assessBatchAdvance({
+      batch: stopped.batch,
+      acknowledgements: [ackFor(stopped.batch.admissions[0])],
+      now,
+      sectionZero: writerSection(),
+    });
+    assert.equal(barrier.allowed, false);
+    assert.equal(barrier.releaseChildren, true);
+    assert.equal(barrier.beginNextWave, false);
+    assert.equal(barrier.reason, 'stopped-partial-wave-acks-valid');
+  }
+});
+
+test('stopped partial waves remain distinct from negative and corrupt ACKs', () => {
+  let batch = reserveBatch([1, 2, 3]);
+  batch = recordCreated(
+    batch,
+    batch.admissions[0].admissionToken,
+    '2026-08-29T18:59:50.000Z',
+  );
+  batch = recordCreationOutcome({
+    batch,
+    admissionToken: batch.admissions[1].admissionToken,
+    outcome: 'uncertain',
+    attemptedAt: now,
+  }).batch;
+
+  const negative = assessBatchAdvance({
+    batch,
+    acknowledgements: [ackFor(batch.admissions[0], {
+      ready: false,
+      blocker: 'base changed',
+    })],
+    now,
+    sectionZero: writerSection(),
+  });
+  assert.equal(negative.reason, 'wave-ack-negative');
+  assert.equal(negative.releaseChildren, false);
+
+  const corrupt = assessBatchAdvance({
+    batch,
+    acknowledgements: [ackFor(batch.admissions[0], { session: 'wrong' })],
+    now,
+    sectionZero: writerSection(),
+  });
+  assert.equal(corrupt.reason, 'wave-ack-invalid');
+  assert.equal(corrupt.releaseChildren, false);
+});
+
+test('a stopped wave with no created child cannot advance vacuously', () => {
+  let batch = reserveBatch([1, 2]);
+  batch = recordCreationOutcome({
+    batch,
+    admissionToken: batch.admissions[0].admissionToken,
+    outcome: 'definitive-non-creation',
+    attemptedAt: now,
+  }).batch;
+  const result = assessBatchAdvance({
+    batch,
+    acknowledgements: [],
+    now,
+    sectionZero: writerSection(),
+  });
+  assert.equal(result.reason, 'stopped-wave-no-created-children');
+  assert.equal(result.releaseChildren, false);
+  assert.equal(result.beginNextWave, false);
+});
+
+test('ACK timeout is derived from wave closure and inspected exactly once', () => {
+  let batch = closeCreatedWave(reserveBatch([1, 2]));
+  const acknowledgements = [ackFor(batch.admissions[0])];
   assert.equal(assessBatchAdvance({
-    batch: restarted,
-    acknowledgements: allAcks,
+    batch,
+    acknowledgements,
+    now: '2026-08-29T19:04:59.999Z',
+    ackDeadline: '2099-01-01T00:00:00.000Z',
+    sectionZero: writerSection('admit', '2026-08-29T19:04:59.999Z'),
+  }).reason, 'wave-acks-pending');
+
+  const timedOut = assessBatchAdvance({
+    batch,
+    acknowledgements,
     now: '2026-08-29T19:05:00.000Z',
-    ackDeadline: '2026-08-29T19:05:00.000Z',
     sectionZero: writerSection('admit', '2026-08-29T19:05:00.000Z'),
-  }).allowed, false);
+  });
+  assert.equal(timedOut.reason, 'ack-timeout-inspect-required');
+  assert.equal(timedOut.inspectOnce, true);
+  assert.equal(timedOut.replaceChildren, false);
+
+  const inspected = recordAckInspection({
+    batch,
+    inspectedAt: '2026-08-29T19:05:00.000Z',
+  });
+  assert.equal(inspected.recorded, true);
+  batch = inspected.batch;
+  assert.equal(recordAckInspection({
+    batch,
+    inspectedAt: '2026-08-29T19:06:00.000Z',
+  }).reason, 'ack-inspection-already-recorded');
   assert.equal(assessBatchAdvance({
-    batch: restarted,
-    acknowledgements: allAcks,
+    batch,
+    acknowledgements,
     now: '2026-08-29T19:05:00.000Z',
-    ackDeadline: '2026-08-29T19:05:00.000Z',
     sectionZero: writerSection('admit', '2026-08-29T19:05:00.000Z'),
-    reconciliationComplete: true,
+  }).reason, 'wave-acks-pending-after-inspection');
+  assert.equal(assessBatchAdvance({
+    batch,
+    acknowledgements: batch.admissions.map(ackFor),
+    now: '2026-08-29T19:05:00.000Z',
+    sectionZero: writerSection('admit', '2026-08-29T19:05:00.000Z'),
   }).allowed, true);
 });
 
+test('restart requires the same inspect-once path and never replacement', () => {
+  const batch = closeCreatedWave(reserveBatch([1, 2]));
+  const result = assessBatchAdvance({
+    batch,
+    acknowledgements: [ackFor(batch.admissions[0])],
+    now,
+    sectionZero: writerSection(),
+    restarted: true,
+  });
+  assert.equal(result.reason, 'restart-inspect-required');
+  assert.equal(result.inspectOnce, true);
+  assert.equal(result.replaceChildren, false);
+});
+
 test('batch release requires current writer authorization', () => {
-  const batch = {
-    id: 'batch-1',
-    authorization: writerSection().authorization,
-    admissions: [admission(1)],
-  };
+  const batch = closeCreatedWave(reserveBatch([1]));
   const result = assessBatchAdvance({
     batch,
     acknowledgements: batch.admissions.map(ackFor),
     now,
-    ackDeadline: '2026-08-29T19:05:00.000Z',
     sectionZero: assessSectionZero({
       operation: 'admit',
       stateAvailable: true,
@@ -293,26 +525,24 @@ test('batch release requires current writer authorization', () => {
 });
 
 test('batch release rejects mismatched embedded batch identity', () => {
+  const valid = closeCreatedWave(reserveBatch([1]));
   for (const batch of [
     {
-      id: 'batch-1',
-      authorization: writerSection().authorization,
-      admissions: [{ ...admission(1), batchId: 'other-batch' }],
+      ...valid,
+      admissions: [{ ...valid.admissions[0], batchId: 'other-batch' }],
     },
     {
-      id: 'batch-1',
+      ...valid,
       authorization: {
-        ...writerSection().authorization,
+        ...valid.authorization,
         batchId: 'other-batch',
       },
-      admissions: [admission(1)],
     },
   ]) {
     const result = assessBatchAdvance({
       batch,
       acknowledgements: batch.admissions.map(ackFor),
       now,
-      ackDeadline: '2026-08-29T19:05:00.000Z',
       sectionZero: writerSection(),
     });
     assert.equal(result.allowed, false);
@@ -331,44 +561,82 @@ test('batch creation and spawning reject stale or unbound writer authorization',
   }).ready, false);
 
   const statusAuthorization = writerSection('status');
+  const batch = reserveBatch([1]);
   assert.equal(assessSpawnAttempt({
     now,
     previousAttemptAt: null,
     sectionZero: statusAuthorization,
     batchId: 'batch-1',
+    admission: batch.admissions[0],
     duplicateCheck: true,
     collisionCheck: true,
+    issueReady: true,
+    capacityAvailable: true,
   }).allowed, false);
 });
 
 test('ambiguous creation blocks fallback and definitive non-creation permits one same-token fallback', () => {
+  const batch = reserveBatch([1]);
+  const cloudAttemptAt = '2026-08-29T18:59:50.000Z';
   const spawnAttempt = assessSpawnAttempt({
     now,
-    previousAttemptAt: '2026-08-29T18:59:50.000Z',
+    previousAttemptAt: cloudAttemptAt,
     sectionZero: writerSection(),
+    admission: batch.admissions[0],
     duplicateCheck: true,
     collisionCheck: true,
+    issueReady: true,
+    capacityAvailable: true,
     batchId: 'batch-1',
     creationOutcome: 'definitive-non-creation',
   });
   assert.equal(assessLocalFallback({
-    admissionToken: 'token',
-    originalAdmissionToken: 'token',
+    admissionToken: batch.admissions[0].admissionToken,
+    originalAdmissionToken: batch.admissions[0].admissionToken,
+    batchId: batch.id,
+    cloudAttemptAt,
     cloudOutcome: 'uncertain',
     spawnAttempt,
   }).allowed, false);
   assert.equal(assessLocalFallback({
-    admissionToken: 'token',
-    originalAdmissionToken: 'token',
+    admissionToken: batch.admissions[0].admissionToken,
+    originalAdmissionToken: batch.admissions[0].admissionToken,
+    batchId: batch.id,
+    cloudAttemptAt,
     cloudOutcome: 'definitive-non-creation',
     spawnAttempt,
   }).allowed, true);
   assert.equal(assessLocalFallback({
     admissionToken: 'replacement',
-    originalAdmissionToken: 'token',
+    originalAdmissionToken: batch.admissions[0].admissionToken,
+    batchId: batch.id,
+    cloudAttemptAt,
     cloudOutcome: 'definitive-non-creation',
     spawnAttempt,
   }).allowed, false);
+  assert.equal(assessLocalFallback({
+    admissionToken: batch.admissions[0].admissionToken,
+    originalAdmissionToken: batch.admissions[0].admissionToken,
+    batchId: 'other-batch',
+    cloudAttemptAt,
+    cloudOutcome: 'definitive-non-creation',
+    spawnAttempt,
+  }).reason, 'fallback-attempt-correlation-invalid');
+});
+
+test('writer timestamps require timezone-qualified RFC 3339 values', () => {
+  for (const malformed of [
+    '2026-08-29',
+    '2026-08-29T19:00:00',
+    '2026-02-30T19:00:00.000Z',
+    '2026-08-29T25:00:00.000Z',
+    '2026-08-29T19:00:00.0000Z',
+  ]) {
+    assert.equal(assessAtomicOwnership(
+      { ...writerCapability, verifiedAt: malformed },
+      { now, repository: 'Jamula/Andreja', ownerId: 'coordinator-1' },
+    ).available, false);
+  }
 });
 
 test('approved work is handed off and never directly merged', () => {
@@ -378,16 +646,22 @@ test('approved work is handed off and never directly merged', () => {
   });
 });
 
-test('prompt and templates carry universal Section 0, batch ACK, and no-merge contracts', () => {
+test('prompt and every orchestration contract carry the five-child wave rules', () => {
   const root = path.resolve(__dirname, '../../..');
   const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
   const prompt = read('.squad/skills/squad-issue-drain/PROMPT.md');
   const coordinator = read('.github/agents/squad.agent.md');
   const coordinatorTemplate = read('.squad/templates/squad.agent.md.template');
   const ralph = read('.squad/templates/ralph-reference.md');
+  const ralphInstructions = read('.squad/ralph-instructions.md');
+  const ralphInstructionsTemplate = read('.squad/templates/ralph-instructions.md');
   const lifecycle = read('.squad/templates/issue-lifecycle.md');
   const spawn = read('.squad/templates/spawn-reference.md');
+  const client = read('.squad/templates/client-compatibility-reference.md');
+  const orchestrationLog = read('.squad/templates/orchestration-log.md');
   const scribe = read('.squad/templates/after-agent-reference.md');
+  const scribeCharter = read('.squad/agents/scribe/charter.md');
+  const scribeCharterTemplate = read('.squad/templates/scribe-charter.md');
   const workflowGuide = read('.squad/templates/workflow-wiring-guide.md');
   const workflowAppendix = read(
     '.squad/templates/workflow-wiring-appendix-a-code-reviewer.md',
@@ -398,14 +672,38 @@ test('prompt and templates carry universal Section 0, batch ACK, and no-merge co
     assert.match(content, /Section 0/i);
   }
   assert.match(prompt, /up to five/i);
-  assert.match(prompt, /at least 10 seconds/i);
-  assert.match(prompt, /every child.*ACK/is);
-  assert.match(prompt, /release.*all.*ACK/is);
+  assert.match(prompt, /exact 10-second boundary/i);
+  assert.match(prompt, /every successfully created child/i);
+  assert.match(prompt, /stopped\s+partial wave/i);
+  assert.match(prompt, /inspect.*exactly once/is);
+  assert.match(prompt, /NEXT_TICK_REQUIRED/);
+  assert.match(prompt, /useful N\/5 target/);
   assert.match(prompt, /read-only/i);
   assert.match(prompt, /atomic.*capabilit/i);
   assert.match(prompt, /generic Scribe/i);
-  assert.match(spawn, /five simultaneous/i);
+  assert.match(spawn, /Reserve five child issues/i);
   assert.match(spawn, /ambiguous.*creation/is);
+  assert.match(client, /never\s+manufacture concurrency/i);
+  assert.match(lifecycle, /every successfully created child returns/i);
+  assert.match(orchestrationLog, /stopped partial wave/i);
+  assert.match(scribe, /five-minute inspect-once/i);
+  assert.match(scribeCharter, /all and only.*successfully created children/is);
+  assert.equal(scribeCharter, scribeCharterTemplate);
+  assert.equal(ralphInstructions, ralphInstructionsTemplate);
+  for (const content of [
+    prompt,
+    coordinator,
+    coordinatorTemplate,
+    ralph,
+    ralphInstructions,
+    lifecycle,
+    spawn,
+    client,
+  ]) {
+    assert.doesNotMatch(content, /all admitted children/i);
+    assert.doesNotMatch(content, /4-5 simultaneous/i);
+    assert.doesNotMatch(content, /all actionable issues simultaneously/i);
+  }
   for (const content of [
     coordinator,
     coordinatorTemplate,

--- a/.squad/templates/after-agent-reference.md
+++ b/.squad/templates/after-agent-reference.md
@@ -11,14 +11,17 @@
 
 **⚡ Context budget rule:** After collecting results from 3+ agents, use compact format (agent + 1-line outcome). Full details go in orchestration log via Scribe.
 
-After each batch of agent work:
+After each ordinary batch of agent work, or after issue drain has explicitly
+released the successfully created members of a wave:
 
 1. **Collect results** via `read_agent` (wait: true, timeout: 300).
 
 2. **Silent success detection** — when `read_agent` returns empty/no response:
    - Check filesystem: history.md modified? New decision inbox files? Output files created?
    - Files found → `"⚠️ {Name} completed (files verified) but response lost."` Treat as DONE.
-   - No files → `"❌ {Name} failed — no work product."` Consider re-spawn.
+   - No files → `"❌ {Name} failed — no work product."` Consider re-spawn only
+     for ordinary work. Issue drain never replaces a missing or uncertain child;
+     it preserves ownership and follows its five-minute inspect-once rule.
 
 3. **Show compact results:** `{emoji} {Name} — {1-line summary of what they did}`
 
@@ -27,6 +30,10 @@ After each batch of agent work:
    or awaiting read-back. Exclusive completion takes precedence. Do not start
    generic Scribe until its single conditional-create attempt has a reconciled
    outcome:
+   For issue drain, the spawn manifest must preserve the reserved wave/batch ID,
+   stable tokens, all successfully created children, stopped-partial status, ACK
+   dispositions, and release state. Scribe must not turn missing/negative ACKs
+   or uncertain creation into release, advancement, or replacement.
 
 ```
 agent_type: "general-purpose"

--- a/.squad/templates/client-compatibility-reference.md
+++ b/.squad/templates/client-compatibility-reference.md
@@ -8,20 +8,38 @@ Squad runs on multiple Copilot surfaces. The coordinator MUST detect its platfor
 
 Before spawning agents, determine the platform by checking available tools:
 
-1. **CLI mode** — `task` tool is available → full spawning control. Use `task` with `agent_type`, `mode`, `model`, `description`, `prompt` parameters. Collect results via `read_agent`.
+1. **App mode** — `create_session` is available → persistent child sessions.
+   Issue drain may use reserved waves of five only when the App confirms that
+   capacity; a lower confirmed limit reduces the wave.
 
-2. **VS Code mode** — `runSubagent` or `agent` tool is available → conditional behavior. Use `runSubagent` with the task prompt. Drop `agent_type`, `mode`, and `model` parameters. Multiple subagents in one turn run concurrently (equivalent to background mode). Results return automatically — no `read_agent` needed.
+2. **CLI mode** — `task` tool is available → full spawning control. Use `task` with `agent_type`, `mode`, `model`, `description`, `prompt` parameters. Collect results via `read_agent`.
 
-3. **Fallback mode** — neither `task` nor `runSubagent`/`agent` available → work inline. Do not apologize or explain the limitation. Execute the task directly.
+3. **VS Code mode** — `runSubagent` or `agent` tool is available → conditional behavior. Use `runSubagent` with the task prompt. Drop `agent_type`, `mode`, and `model` parameters. Multiple subagents in one turn run concurrently (equivalent to background mode). Results return automatically — no `read_agent` needed.
 
-If both `task` and `runSubagent` are available, prefer `task` (richer parameter surface).
+4. **Fallback mode** — none of the spawn tools above are available → work inline. Do not apologize or explain the limitation. Execute the task directly.
+
+Prefer `create_session` for issue-drain children. If both `task` and
+`runSubagent` are available outside App mode, prefer `task` (richer parameter
+surface).
+
+Issue-drain pacing overrides each client's generic fan-out behavior. Reserve
+each selected issue, launch one child at each exact 10-second boundary, and use
+a supported one-time wake or `NEXT_TICK_REQUIRED` instead of sleeping. Do not
+wait for an individual ACK before the next same-wave launch. Do not start the
+next wave until every successfully created child returns a valid correlated
+ACK. A client without atomic reservation, confirmed capacity, or a supported
+wake/tick path must reduce capacity or remain read-only; it must never
+manufacture concurrency.
 
 #### VS Code Spawn Adaptations
 
 When in VS Code mode, the coordinator changes behavior in these ways:
 
 - **Spawning tool:** Use `runSubagent` instead of `task`. The prompt is the only required parameter — pass the full agent prompt (charter, identity, task, hygiene, response order) exactly as you would on CLI.
-- **Parallelism:** Spawn ALL concurrent agents in a SINGLE turn. They run in parallel automatically. This replaces `mode: "background"` + `read_agent` polling.
+- **Parallelism:** For ordinary routed work, spawn all concurrent agents in a
+  single turn. Issue drain is the exception: it paces one reserved child per
+  10-second boundary and stops the remaining wave on failed/ambiguous creation,
+  changed eligibility, lost capacity, or a closed safety gate.
 - **Model selection:** Accept the session model. Do NOT attempt per-spawn model selection or fallback chains — they only work on CLI. In Phase 1, all subagents use whatever model the user selected in VS Code's model picker.
 - **Scribe:** Cannot fire-and-forget. Batch Scribe as the LAST subagent in any parallel group. Scribe is light work (file ops only), so the blocking is tolerable.
 - **Launch table:** Skip it. Results arrive with the response, not separately. By the time the coordinator speaks, the work is already done.

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -294,6 +294,23 @@ git worktree remove ../worktrees/{issue-number}
 
 When spawning an agent to work on an issue, include this context block:
 
+Issue-drain admissions also follow the stricter wave lifecycle before this
+ordinary implementation flow:
+
+1. Reserve up to five independent issues under the verified atomic owner,
+   reduced by the lower confirmed platform limit.
+2. Create one reserved child at each exact 10-second boundary using a one-time
+   wake or `NEXT_TICK_REQUIRED`, without waiting for the preceding ACK.
+3. Stop all later launches on failed/ambiguous creation, changed eligibility,
+   lost capacity, or a closed safety gate. Preserve created children; do not
+   replace uncertainty.
+4. Keep created children paused until every successfully created child returns
+   a valid correlated ACK. Missing or negative ACKs block; invalid/corrupt ACKs
+   are a distinct failure. Inspect once at five minutes or restart.
+5. A completed wave may advance after the barrier. A stopped partial wave may
+   release ACKed created children but cannot begin the next wave until its stop
+   reason and a fresh admission scan are reconciled.
+
 ```markdown
 ## ISSUE CONTEXT
 

--- a/.squad/templates/orchestration-log.md
+++ b/.squad/templates/orchestration-log.md
@@ -12,6 +12,10 @@
 | **Why chosen** | {Routing rationale — what in the request matched this agent} |
 | **Mode** | {`background` / `sync`} |
 | **Why this mode** | {Brief reason — e.g., "No hard data dependencies" or "User needs to approve architecture"} |
+| **Issue-drain wave** | {wave/batch ID or `not-applicable`} |
+| **Admission token** | {stable token or `not-applicable`} |
+| **Reservation / creation** | {reserved → created / failed / ambiguous / ineligible / unlaunched} |
+| **ACK / release** | {pending / valid / negative / invalid / released / stopped-partial} |
 | **Files authorized to read** | {Exact file paths the agent was told to read} |
 | **File(s) agent must produce** | {Exact file paths the agent is expected to create or modify} |
 | **Outcome** | {Completed / Rejected by {Reviewer} / Escalated} |
@@ -25,3 +29,6 @@
 3. **Update outcome AFTER the agent completes.** Fill in the Outcome field.
 4. **Never delete or edit past entries.** Append-only.
 5. **If a reviewer rejects work,** log the rejection as a new entry with the revision agent.
+6. **Issue-drain entries reflect the ledger.** Log only observed reservation,
+   creation, ACK, and release outcomes. A stopped partial wave is not an invalid
+   ACK set, and an uncertain child is never logged as replaced.

--- a/.squad/templates/ralph-instructions.md
+++ b/.squad/templates/ralph-instructions.md
@@ -18,7 +18,8 @@
     • Agent persona, tone, or verbosity for session output
 
   YOU CANNOT override via this file:
-    • Parallelism — Ralph always spawns agents for all actionable issues simultaneously
+    • Issue-drain safety — Ralph uses reserved waves of five, lower confirmed
+      capacity, exact 10-second spawn-attempt pacing, and the created-child ACK barrier
     • Core eligibility filter (squad/squad:* label required, not blocked, not assigned)
     • The underlying `gh` / Copilot CLI command used to spawn each session
 
@@ -45,12 +46,21 @@
 ## Ralph, Go!
 
 Read this file for your full instructions.  Follow ALL sections.
-MAXIMIZE PARALLELISM — spawn agents for ALL actionable issues simultaneously.
+MAXIMIZE SAFE PARALLELISM — enumerate all actionable issues, then admit them
+through `.squad/skills/squad-issue-drain/PROMPT.md`. Reserve waves of five or
+lower confirmed capacity. Launch one reserved member per exact 10-second
+boundary without sleeping and without waiting for each individual ACK.
 
 ### Issue Selection
 
 Work on every open, unblocked, unassigned issue labeled `squad` or `squad:{member}`.
 Skip issues that are assigned to a human, blocked, or marked `status:on-hold`.
+Before creating a child, atomically reserve its issue. A failed/ambiguous
+creation, changed eligibility, lost capacity, or closed safety gate stops the
+remainder of the wave. Keep every successfully created child owned and paused
+until all such children return valid ACKs. Missing, negative, or corrupt ACKs
+block the next wave; inspect once after five minutes and never replace an
+uncertain child.
 
 ### Post-Task Actions
 
@@ -65,4 +75,5 @@ After completing work on each issue:
 
 If you are blocked on an issue, comment on it explaining why, add the appropriate
 `blocked:dependency`, `blocked:evidence`, or `blocked:human` label, and move to
-the next actionable item. Do not halt the loop.
+the next actionable item only after the current wave's stop and ACK state is
+reconciled. Do not continue launching the remainder of a stopped wave.

--- a/.squad/templates/ralph-reference.md
+++ b/.squad/templates/ralph-reference.md
@@ -41,6 +41,18 @@ remain fail-closed before Step 1 and follow the contract's recovery path. Do not
 duplicate its state algorithm or write runtime-owned state directly. Exclusive
 retrospective completion must finish before generic Scribe work starts.
 
+**Issue-drain wave contract:** Reserve at most five independent `READY` issues
+before creation, reduced by the lower confirmed platform limit. Launch one
+reserved child at each exact 10-second boundary using a supported one-time wake
+or `NEXT_TICK_REQUIRED`; never sleep in a turn. Do not wait for one child's ACK
+before launching the next reserved member. Failed/ambiguous creation, changed
+eligibility, lost capacity, or a closed safety gate stops the rest of the wave.
+Keep successfully created children owned and paused. Release only after every
+successfully created child returns a valid correlated ACK. Missing or negative
+ACKs block; invalid/corrupt ACKs are reported separately. At five minutes or
+restart, inspect once and never replace while creation or ownership is
+uncertain. A stopped partial wave cannot begin the next wave.
+
 **Step 1 — Scan for work** (run these in parallel):
 
 ```bash
@@ -71,9 +83,12 @@ gh pr list --state open --draft --json number,title,author,labels,checks --limit
 
 **Step 3 — Act on highest-priority item:**
 - Process one category at a time, highest priority first (untriaged > assigned > CI failures > review feedback > approved PRs)
-- Spawn agents as needed, collect results
+- For ordinary work, spawn agents as needed and collect results. For issue
+  drain, use the reserved five-child wave contract above.
 - **⚡ CRITICAL: After results are collected, DO NOT stop. DO NOT wait for user input. IMMEDIATELY go back to Step 1 and scan again.** This is a loop — Ralph keeps cycling until the board is clear or the user says "idle". Each cycle is one "round".
-- If multiple items exist in the same category, process them in parallel (spawn multiple agents)
+- If multiple items exist in the same category, process ordinary routed work in
+  parallel. Issue-drain children are paced one spawn attempt per 10-second
+  boundary and use the all-successfully-created-child ACK barrier.
 
 **Step 4 — Periodic check-in** (every 3-5 rounds):
 

--- a/.squad/templates/scribe-charter.md
+++ b/.squad/templates/scribe-charter.md
@@ -18,6 +18,15 @@ authorized by issue drain. Do not use plain `squad_state_write`, overwrite an
 existing key, retry an uncertain result, or run normal inbox/log/history
 maintenance. A conflict or unavailable capability fails closed.
 
+## Issue-drain wave evidence
+
+When a spawn manifest belongs to issue drain, preserve its wave/batch ID,
+stable admission tokens, reservations, creation outcomes, ACK dispositions, and
+release state exactly as observed. The ACK barrier covers all and only
+successfully created children. Record a stopped partial wave separately from a
+negative or invalid/corrupt ACK set. Never infer release, next-wave admission,
+or replacement from silence, a failed create, or an uncertain child.
+
 ## What I Own
 
 - `.squad/log/` — session logs (what happened, who worked, what was decided)

--- a/.squad/templates/spawn-reference.md
+++ b/.squad/templates/spawn-reference.md
@@ -36,15 +36,20 @@ When `create_session` is available, spawn commit-producing agents as **sub-sessi
 
 **Constraints:**
 - **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
-- **Issue-drain batch cap:** Up to five simultaneous child issue sessions,
-  further capped
+- **Issue-drain wave cap:** Reserve five child issues before creation, reduced
   by lower verified platform capacity and every safety gate. Do not infer
   capacity from configured limits or prior success.
-- **Pacing:** Space every child spawn attempt by at least 10 seconds, including
-  failures and fallback attempts. Follow the issue-drain prompt rather than
-  sleeping inside a turn.
-- **ACK gate:** Preallocate a batch ID and admission token per child. Keep every
-  child paused until all admitted children return correlated valid ACKs.
+- **Pacing:** Launch one reserved child at each exact 10-second boundary,
+  including boundaries after failures and fallback attempts. Use a supported
+  one-time wake or `NEXT_TICK_REQUIRED`; never sleep inside a turn.
+- **ACK gate:** Preallocate a wave/batch ID and admission token per reservation.
+  Launch the next same-wave member without waiting for an individual ACK. Keep
+  every created child paused until the spawn phase closes and all successfully
+  created children return correlated valid ACKs.
+- **Partial wave:** Failed/ambiguous creation, changed eligibility, lost
+  capacity, or a closed safety gate stops every later launch. Preserve created
+  children and their reservations. A stopped partial wave is not an
+  invalid/corrupt ACK set and cannot begin the next wave.
 - **Fallback:** A failed `create_session` may fall back exactly once only after
   definitive evidence that no session, branch, worktree, or PR was created.
   Reuse the same admission token and honor the 10-second attempt spacing.

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -80,9 +80,9 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 - Use `create_session` for agents that produce commits (code, config, docs)
 - Use `task` tool for pure analysis, coordination, or read-only research
 - **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
-- **Concurrency:** Generic work may use 4-5 simultaneous sub-sessions. Issue
-  drain uses one batch of up to five child issue sessions, capped by lower
-  verified platform capacity and every safety gate.
+- **Concurrency:** Generic work may use up to five simultaneous sub-sessions.
+  Issue drain uses waves of five child issue sessions, reduced by lower verified
+  platform capacity and every safety gate.
 - **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
 - **Fallback:** Outside issue drain, a definitive `create_session` failure may
   use `task`. Issue drain permits exactly one paced local fallback only after
@@ -478,9 +478,12 @@ Never crash or halt because an MCP tool is missing. MCP tools are enhancements, 
 
 > **⚠️ Issue-drain exception:** Queue work is governed by
 > `.squad/skills/squad-issue-drain/PROMPT.md`. Universal Section 0, verified
-> atomic ownership, lower App capacity, 10-second spawn-attempt pacing,
-> correlated all-ACK batch release, and ambiguous-creation rules override eager
-> execution and generic fan-out.
+> atomic issue reservations, lower App capacity, exact 10-second spawn-attempt
+> pacing without in-turn sleep, and the all-successfully-created-child ACK
+> barrier override eager execution and generic fan-out. Launch same-wave members
+> without waiting for individual ACKs. A failed/ambiguous creation, changed
+> eligibility, lost capacity, or closed safety gate stops the remainder of that
+> wave without replacement and blocks the next wave.
 
 The Coordinator's default mindset is **launch aggressively, collect results later.**
 
@@ -516,8 +519,11 @@ Before spawning, assess: **is there a reason this MUST be sync?** If not, use ba
 
 ### Parallel Fan-Out
 
-This section governs ordinary routed work only. Issue-drain queue admission uses
-its stricter batch contract and must not launch all children in one tool turn.
+This section governs ordinary routed work only. Issue-drain queue admission
+reserves up to five issues, launches one reserved child per exact 10-second
+boundary without waiting for individual ACKs, and must not launch all children
+in one tool turn. It releases only after the spawn phase closes and every
+successfully created child returns a valid correlated ACK.
 
 When the user gives any task, the Coordinator MUST:
 
@@ -922,6 +928,16 @@ existing repository-scoped atomic lease or conditional-create/CAS capability.
 Without it, remain read-only and claim no exclusivity. If Section 0 runs
 `Retrospective with Enforcement`, use the exclusive weekly retrospective Scribe
 completion mode in this file.
+
+Ralph must follow the five-child wave ledger rather than generic simultaneous
+fan-out: reserve each issue before creation, use a one-time wake or
+`NEXT_TICK_REQUIRED` at every 10-second boundary, and do not wait for an
+individual ACK before launching the next reserved member. Any failed or
+ambiguous creation, changed eligibility, lost capacity, or closed safety gate
+stops the remaining wave. Every successfully created child remains owned and
+paused until the all-created-child ACK barrier passes. A negative, missing, or
+invalid ACK blocks the next wave; timeout/restart permits one inspection at five
+minutes and never replacement while ownership is uncertain.
 
 Ralph may classify an approved, check-passing PR as
 `READY_FOR_AGENT_MERGE`, but MUST NOT merge, auto-merge, enqueue, or activate


### PR DESCRIPTION
## Why

Issue drain needs higher safe throughput without weakening unique ownership, retrospective, dependency, collision, stale-base, validation, or landing gates. This change implements governed decision `539faedf-a051-4a06-840f-6ffbec6c753d` by admitting reserved waves of up to five child sessions, paced at 10-second boundaries, with an explicit ACK barrier before another wave can begin.

Closes #135

## Approach

- Reserve every selected issue under verified repository-scoped atomic ownership before child creation.
- Launch one reserved child at each 10-second wake/tick boundary without waiting for prior same-wave ACKs.
- Keep created children paused until all successfully created children return valid correlated ACKs.
- Stop the remainder of a wave on failed or ambiguous creation, changed eligibility, lost capacity, or a closed safety gate; never replace uncertain ownership.
- Preserve the five-minute inspect-once rule and block subsequent waves on missing, negative, invalid, or mismatched ACKs.
- Align coordinator, Ralph, Scribe, lifecycle, spawn, client, and orchestration contracts with deterministic helper coverage.

The implementation respects lower confirmed platform capacity and does not activate Agent Merge, auto-merge, queueing, or direct merge behavior. Agent Merge and the app own landing.

## Charter impact

This is repository-only orchestration governance. It improves operational reliability and evidence quality while preserving user agency, privacy, security, cost, and human approval boundaries. It creates no cloud resources, accounts, subscriptions, public endpoints, or data-processing paths.

## Validation

- `node --test .squad\skills\squad-issue-drain\issue-drain.test.js .squad\skills\squad-issue-drain\weekly-retrospective.test.js` - passed, 40 tests.
- `python .github\scripts\check_docs_consistency.test.py` - passed, 20 tests.
- `python scripts\docs\generate_architecture_diagram.py --check` - passed.
- `python scripts\docs\test_architecture_diagram.py` - passed, 21 tests.
- `git diff --check` - passed.
- `python .github\scripts\check_docs_consistency.py` - blocked by the pre-existing `docs/operating-model.md` status-artifact hash mismatch on `origin/main`; this PR does not modify that file.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [ ] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

**Blocker:** The unrelated baseline docs status-artifact hash mismatch must be resolved or explicitly dispositioned before this draft is marked ready.

## Stack

N/A. This PR targets `main` directly.