### PR TITLE
Update managed NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ remains pending explicit ratification.
 
 - Git.
 - .NET SDK 10.0.301, pinned by [`global.json`](global.json).
-- `dotnet-ef` 10.0.9 for migration inspection and script generation.
+- `dotnet-ef` 10.0.11 for migration inspection and script generation.
 - Python 3, available as `python`, for documentation consistency checks.
 - PowerShell 7 for repository validation scripts.
 - Node.js 22 and Microsoft Edge for browser, passkey, viewport, and telemetry
@@ -32,12 +32,12 @@ node --version
 
 $efVersion = dotnet ef --version 2>$null
 if ($LASTEXITCODE -ne 0) {
-  dotnet tool install --global dotnet-ef --version 10.0.9
+  dotnet tool install --global dotnet-ef --version 10.0.11
   $efVersion = dotnet ef --version
 }
 $efVersionText = $efVersion -join "`n"
-if ($LASTEXITCODE -ne 0 -or $efVersionText -notmatch "10\.0\.9") {
-  throw "Install or update the global dotnet-ef tool to version 10.0.9."
+if ($LASTEXITCODE -ne 0 -or $efVersionText -notmatch "10\.0\.11") {
+  throw "Install or update the global dotnet-ef tool to version 10.0.11."
 }
 ```
 

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="MSTest.Sdk/4.3.3">
   <PropertyGroup>
     <TestingExtensionsProfile>Default</TestingExtensionsProfile>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.10.0</MicrosoftTestingExtensionsCodeCoverageVersion>
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
@@ -6,7 +6,7 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Why

Refresh the repository-managed dependency graph to current stable releases so builds, test infrastructure, telemetry, database access, and EF tooling stay supported and free of known stale direct packages.

N/A - no source issue was provided.

## Approach

Updated centrally managed NuGet versions, including compatible major upgrades for Microsoft.NET.Test.Sdk and xunit.runner.visualstudio. Updated the separate MSTest MTP and xUnit v3 evidence projects to matching stable test and coverage packages, and kept the documented dotnet-ef prerequisite aligned at 10.0.11. The repository has no application npm dependencies, npm workspaces, or committed npm lockfiles; `.squad/templates/package.json` only declares `type: commonjs`.

No direct package remains below the latest stable release, and no prerelease package, package manager, target framework, or runtime was introduced.

## Charter impact

This is a maintenance-only dependency refresh. It does not change user agency, data handling, tenant boundaries, AI behavior, stakeholder incentives, or ownership. Operability and evidence improve by keeping supported stable packages and test tooling current; the NuGet vulnerability scan found no direct or transitive findings.

## Validation

Passed:

```powershell
dotnet restore Andreja.slnx
dotnet restore tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj
dotnet build Andreja.slnx --configuration Debug --no-restore
dotnet build Andreja.slnx --configuration Release --no-restore
dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Debug --no-restore
dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Release --no-restore
dotnet test Andreja.slnx --configuration Debug --no-build
dotnet test Andreja.slnx --configuration Release --no-build
dotnet format Andreja.slnx --verify-no-changes --no-restore
dotnet format tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --verify-no-changes --no-restore
pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1
pwsh -NoProfile -File .github\scripts\invoke-nuget-vulnerability-scan.ps1
dotnet ef migrations has-pending-model-changes --project src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj --context AndrejaIdentityDbContext
```

Final dependency audit reported no stale direct NuGet packages. The npm surface has no dependencies; install/outdated checks produced no changes or stale packages.

Known baseline limitations:

- Live PostgreSQL tests were not run because the pinned disposable local image was unavailable.
- `python .github\scripts\check_docs_consistency.py` reports the pre-existing `docs/operating-model.md` hash mismatch.
- `npm audit` is not applicable because the repository has no npm lockfile or npm dependencies.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [ ] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

The validation gate remains unchecked only for the explicitly documented baseline/live-environment limitations above; all dependency-relevant local checks passed.

## Stack

N/A - standalone change targeting `main`.