### PR TITLE
Update pinned checkout actions to Node.js 24

### DIFF
--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -24,7 +24,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/dotnet-validation.yml
+++ b/.github/workflows/dotnet-validation.yml
@@ -31,7 +31,7 @@ jobs:
         configuration: [Debug, Release]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -157,7 +157,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -209,7 +209,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/issue-status-tests.yml
+++ b/.github/workflows/issue-status-tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/issue-status.yml
+++ b/.github/workflows/issue-status.yml
@@ -49,7 +49,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check out trusted default-branch automation
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/oci-supply-chain.yml
+++ b/.github/workflows/oci-supply-chain.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout without persisted credentials
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -43,7 +43,7 @@ jobs:
     needs: policy
     steps:
       - name: Checkout reviewed source without persisted credentials
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -98,7 +98,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout the exact tagged revision without persisted credentials
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -27,7 +27,7 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f

--- a/.github/workflows/review-gate-app-tests.yml
+++ b/.github/workflows/review-gate-app-tests.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/selective-ci-shadow.yml
+++ b/.github/workflows/selective-ci-shadow.yml
@@ -72,7 +72,7 @@ jobs:
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout only the trusted base revision
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
           path: trusted-ci
@@ -264,10 +264,11 @@ jobs:
     steps:
       - id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || 'missing-pull-request-merge-sha') || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
@@ -292,10 +293,11 @@ jobs:
     steps:
       - id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || 'missing-pull-request-merge-sha') || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: global.json
@@ -362,10 +364,11 @@ jobs:
     steps:
       - id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || 'missing-pull-request-merge-sha') || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: global.json
@@ -403,10 +406,11 @@ jobs:
     steps:
       - id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || 'missing-pull-request-merge-sha') || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
         with:
@@ -437,10 +441,11 @@ jobs:
     steps:
       - id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || 'missing-pull-request-merge-sha') || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Set up pinned Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -472,10 +477,11 @@ jobs:
     steps:
       - id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && (github.event.pull_request.merge_commit_sha || 'missing-pull-request-merge-sha') || github.event.merge_group.head_sha || github.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           global-json-file: global.json

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check triage script
         id: check-script

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Identify assigned member and trigger work
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -12,7 +12,7 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Enforce mutual exclusivity
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Triage issue via Lead agent
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -19,7 +19,7 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Parse roster and sync labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9

--- a/.squad/templates/workflows/squad-ci.yml
+++ b/.squad/templates/workflows/squad-ci.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.squad/templates/workflows/squad-docs.yml
+++ b/.squad/templates/workflows/squad-docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.squad/templates/workflows/squad-heartbeat.yml
+++ b/.squad/templates/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.squad/templates/workflows/squad-insider-release.yml
+++ b/.squad/templates/workflows/squad-insider-release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.squad/templates/workflows/squad-issue-assign.yml
+++ b/.squad/templates/workflows/squad-issue-assign.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Identify assigned member and trigger work
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.squad/templates/workflows/squad-label-enforce.yml
+++ b/.squad/templates/workflows/squad-label-enforce.yml
@@ -12,7 +12,7 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Enforce mutual exclusivity
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.squad/templates/workflows/squad-preview.yml
+++ b/.squad/templates/workflows/squad-preview.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.squad/templates/workflows/squad-promote.yml
+++ b/.squad/templates/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.squad/templates/workflows/squad-release.yml
+++ b/.squad/templates/workflows/squad-release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.squad/templates/workflows/squad-triage.yml
+++ b/.squad/templates/workflows/squad-triage.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Triage issue via Lead agent
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.squad/templates/workflows/sync-squad-labels.yml
+++ b/.squad/templates/workflows/sync-squad-labels.yml
@@ -14,7 +14,7 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Closes #143

Working as Jett Reno (Platform/SRE and Channel Platform Lead)

## Chosen migration

All 37 active/generated workflow references use immutable `actions/checkout` **v7.0.1** SHA `3d3c42e5aac5ba805825da76410c181273ba90b1`.

Evidence:
- Node 20 deprecation guidance: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- v7.0.1 release: https://github.com/actions/checkout/releases/tag/v7.0.1
- Exact tag commit: https://github.com/actions/checkout/commit/3d3c42e5aac5ba805825da76410c181273ba90b1
- Exact commit metadata declares `runs.using: node24`: https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml

## Alternatives considered

- **v6.1.0** (`d23441a48e516b6c34aea4fa41551a30e30af803`) and **v5.1.0** (`fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09`) also declare Node 24, but retain older major lines without a compatibility benefit for this GitHub-hosted-runner repository. v7.0.1 was already used by two workflows, making standardization the smallest maintained choice.
- **v4.4.0** still declares Node 20 and does not satisfy the issue.
- **Custom Git commands** would duplicate authenticated fetch, ref resolution, cleanup, sparse checkout, LFS/submodule, safe-directory, and credential-cleanup behavior, increasing security and maintenance surface.

## Files changed

Active workflows under `.github/workflows/`: `docs-consistency.yml`, `dotnet-validation.yml`, `issue-status-tests.yml`, `issue-status.yml`, `oci-supply-chain.yml`, `powershell.yml`, `review-gate-app-tests.yml`, `selective-ci-shadow.yml`, `squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-label-enforce.yml`, `squad-triage.yml`, and `sync-squad-labels.yml`.

Generated-workflow sources under `.squad/templates/workflows/`: `squad-ci.yml`, `squad-docs.yml`, `squad-heartbeat.yml`, `squad-insider-release.yml`, `squad-issue-assign.yml`, `squad-label-enforce.yml`, `squad-preview.yml`, `squad-promote.yml`, `squad-release.yml`, `squad-triage.yml`, and `sync-squad-labels.yml`.

Existing checkout inputs are preserved. Because v7 blocks fork PR code from `pull_request_target` by default, the six selective-CI steps that intentionally execute operator-approved PR merge commits set `allow-unsafe-pr-checkout: true` to preserve existing sampled-CI behavior.

## Rebase and validation

Preflight/rebase:
- Clean worktree confirmed.
- `git fetch --prune origin` recorded live `origin/main` at `5e82b182d50d430497b3dd8aa42a6ec5a7f831d5` and remote feature tip at `b2cfcf5bf512d9ba11894b7b3e28dccfa565deed`.
- Rebased cleanly, re-fetched, and verified both remote tips were unchanged.
- Pushed rebased commit `1c0dafb8987c71453c7e453bba8ea676c2be3ba8` using exact lease `--force-with-lease=refs/heads/u/cyrusjamula/143-update-checkout-node-24:b2cfcf5bf512d9ba11894b7b3e28dccfa565deed`.

Focused local checks:
- `python -c "from pathlib import Path; import yaml; files=sorted(Path('.github/workflows').glob('*.y*ml'))+sorted(Path('.squad/templates/workflows').glob('*.y*ml')); [yaml.safe_load(p.read_text(encoding='utf-8')) for p in files]; print(f'Parsed {len(files)} workflow YAML files')"` — 25 files parsed.
- Repository-wide assertion over `git grep -n 'actions/checkout@' -- .` — 37/37 exact v7.0.1 full-SHA pins; six expected selective-CI opt-ins.
- `node --test .github/ci/change-classifier.test.js .github/scripts/issue-status.test.js .github/scripts/review-gate-app.test.js` — 277 passed, 0 failed.
- `git diff --check origin/main...HEAD` — passed.

Replacement hosted checks completed:
- Passed: C# and Python CodeQL, Debug/Release builds and tests, DevSkim, PSScriptAnalyzer, pin/failure policy, review-gate fixtures, issue reconciliation, format, NuGet audit, fixture/unit tests, and reproducible OCI build/SBOM/scan/provenance.
- Skipped as designed on a pull request: keyless Sigstore signing/offline verification.
- Failed baseline: docs-consistency `check` still reports the pre-existing `docs/operating-model.md` status-artifact hash mismatch: https://github.com/Jamula/Andreja/actions/runs/33288264017/job/99195233159

The earlier OCI PR-ref failure no longer reproduces on the rebased base; the replacement OCI job passed in 4m23s.

## Risks and blocker

- PR remains **draft** and `UNSTABLE`; do not mark ready while docs consistency fails.
- `python .github/scripts/check_docs_consistency.py` records hash `1e33fcb736a916a6b191c9b36a8bd984e1fdc1f42ad251121df4ac7227a0c7e5` for `docs/operating-model.md`, while current content hashes to `f10ab3a27d076e5eba407f5530366caa70c0e4aae45d695b1a7fb9c96c73eb85`. This PR changes neither docs nor the checker and intentionally does not broaden into governance-hash repair.
- Active/generated workflows use GitHub-hosted runners, which support Node 24. Future self-hosted consumers must satisfy checkout's runner requirements.
- Selective CI intentionally runs operator-approved PR merge code from a trusted trigger. The v7 opt-in preserves the existing boundary and remains constrained by operator labeling, trusted-base classification, no top-level permissions, read-only job permissions, no persisted checkout credentials, and no repository secrets.