### PR TITLE
Simplify Squad issue admission guard

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -477,8 +477,9 @@ Never crash or halt because an MCP tool is missing. MCP tools are enhancements, 
 > **⚠️ Exception:** Eager Execution does NOT apply during Init Mode Phase 1. Init Mode requires explicit user confirmation (via `ask_user`) before creating the team. Do NOT launch file creation, directory scaffolding, or any Phase 2 work until the user confirms the roster.
 
 > **⚠️ Issue-drain exception:** Queue work is governed by
-> `.squad/skills/squad-issue-drain/PROMPT.md`. Universal Section 0, verified
-> atomic issue reservations, lower App capacity, exact 10-second spawn-attempt
+> `.squad/skills/squad-issue-drain/PROMPT.md`. Universal Section 0, the
+> single-coordinator process guard with best-effort repository reconciliation,
+> lower App capacity, exact 10-second spawn-attempt
 > pacing without in-turn sleep, and the all-successfully-created-child ACK
 > barrier override eager execution and generic fan-out. Launch same-wave members
 > without waiting for individual ACKs. A failed/ambiguous creation, changed
@@ -520,7 +521,7 @@ Before spawning, assess: **is there a reason this MUST be sync?** If not, use ba
 ### Parallel Fan-Out
 
 This section governs ordinary routed work only. Issue-drain queue admission
-reserves up to five issues, launches one reserved child per exact 10-second
+prepares up to five issues, launches one prepared child per exact 10-second
 boundary without waiting for individual ACKs, and must not launch all children
 in one tool turn. It releases only after the spawn phase closes and every
 successfully created child returns a valid correlated ACK.
@@ -661,16 +662,17 @@ prompt: |
   Never speak to user. End with plain text summary after all tool calls.
 ```
 
-**Weekly retrospective completion mode (exclusive):** When `Retrospective with
+**Weekly retrospective completion mode (dedicated):** When `Retrospective with
 Enforcement` runs as the issue-drain admission gate, first prove that no generic
 Scribe is running; otherwise stop. Do not start generic Scribe work until the
-exclusive completion attempt finishes and its canonical record is re-read.
+dedicated completion attempt finishes and its canonical record is re-read.
 After the issue-drain contract returns `ready: true`, pass Scribe only its
-returned canonical key and content plus the exact verified repository-scoped
-atomic conditional-create tool. Scribe MUST make exactly one create-if-absent
-attempt; an existing key or uncertain result is failure and must not be
-overwritten or treated as completion. Plain `squad_state_write` does not
-establish exactly-once completion. In this mode suppress generic session,
+returned canonical key and content. After a complete listing proves the key
+absent, Scribe makes one `squad_state_write`, then re-lists and re-reads exact
+content. Reuse an exact valid existing record without another write. Missing,
+different, or uncertain read-back is failure and must not be overwritten or
+treated as completion. This single-coordinator process guard is best-effort
+repository reconciliation, not cross-process exclusivity. In this mode suppress generic session,
 ceremony, orchestration, and health logs plus inbox, decision, and history
 maintenance. This narrow override supersedes Scribe's normal logging contract
 only for this admission-gate ceremony.
@@ -705,7 +707,7 @@ Ceremonies are structured team meetings where agents align before or after work.
 1. Before spawning a work batch, check `.squad/ceremonies.md` for auto-triggered `before` ceremonies matching the current task condition.
 2. After a batch completes, check for `after` ceremonies. Manual ceremonies run only when the user asks.
 3. Spawn the facilitator (sync) using the template in the reference file. Facilitator spawns participants as sub-tasks.
-4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record, except `Retrospective with Enforcement` used as Ralph's admission gate MUST use the exclusive weekly retrospective completion mode above and MUST NOT create a generic ceremony or session log.
+4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record, except `Retrospective with Enforcement` used as Ralph's admission gate MUST use the dedicated weekly retrospective completion mode above and MUST NOT create a generic ceremony or session log.
 5. **Ceremony cooldown:** Skip auto-triggered checks for the immediately following step.
 6. Show: `📋 {CeremonyName} completed — facilitated by {Lead}. Decisions: {count} | Action items: {count}.`
 
@@ -923,16 +925,17 @@ GitHub Issues command, recovery path, restart, heartbeat, or post-batch rescan
 may bypass it. Ralph MUST NOT scan or enumerate issues or PRs until that
 contract permits the requested read-only or writer mode. Section 0 owns the
 fail-closed checks and runtime-state protocol; do not reimplement them or write
-runtime-owned state directly. Writer admission additionally requires verified
-existing repository-scoped atomic lease or conditional-create/CAS capability.
-Without it, remain read-only and claim no exclusivity. If Section 0 runs
-`Retrospective with Enforcement`, use the exclusive weekly retrospective Scribe
+runtime-owned state directly. Writer admission additionally requires the
+single-coordinator process guard and complete best-effort repository
+reconciliation immediately before each spawn. Missing atomic capability does
+not block admission, mutation, retrospective completion, or child release. If
+Section 0 runs `Retrospective with Enforcement`, use the dedicated weekly retrospective Scribe
 completion mode in this file.
 
 Ralph must follow the five-child wave ledger rather than generic simultaneous
-fan-out: reserve each issue before creation, use a one-time wake or
+fan-out: prepare each issue before creation, use a one-time wake or
 `NEXT_TICK_REQUIRED` at every 10-second boundary, and do not wait for an
-individual ACK before launching the next reserved member. Any failed or
+individual ACK before launching the next prepared member. Any failed or
 ambiguous creation, changed eligibility, lost capacity, or closed safety gate
 stops the remaining wave. Every successfully created child remains owned and
 paused until the all-created-child ACK barrier passes. A negative, missing, or

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -9,14 +9,15 @@
 - **Style:** Silent. Never speaks to the user. Works in the background.
 - **Mode:** Always spawned as `mode: "background"`. Never blocks the conversation.
 
-## Exclusive retrospective completion
+## Dedicated retrospective completion
 
 Generic Scribe work must not run while weekly-retrospective completion is
-pending, running, or awaiting canonical read-back. In exclusive completion
-mode, perform only the single repository-scoped atomic conditional create
-authorized by issue drain. Do not use plain `squad_state_write`, overwrite an
-existing key, retry an uncertain result, or run normal inbox/log/history
-maintenance. A conflict or unavailable capability fails closed.
+pending, running, or awaiting canonical read-back. In dedicated completion mode,
+perform only the single canonical `squad_state_write` authorized by issue drain,
+then re-list and re-read exact content. Reuse an exact valid existing record
+without writing. Do not overwrite a conflicting key, retry an uncertain result,
+or run normal inbox/log/history maintenance. A conflict or incomplete
+best-effort repository reconciliation fails closed.
 
 ## Issue-drain wave evidence
 

--- a/.squad/ralph-instructions.md
+++ b/.squad/ralph-instructions.md
@@ -18,7 +18,7 @@
     • Agent persona, tone, or verbosity for session output
 
   YOU CANNOT override via this file:
-    • Issue-drain safety — Ralph uses reserved waves of five, lower confirmed
+    • Issue-drain safety — Ralph uses prepared waves of five, lower confirmed
       capacity, exact 10-second spawn-attempt pacing, and the created-child ACK barrier
     • Core eligibility filter (squad/squad:* label required, not blocked, not assigned)
     • The underlying `gh` / Copilot CLI command used to spawn each session
@@ -47,16 +47,18 @@
 
 Read this file for your full instructions.  Follow ALL sections.
 MAXIMIZE SAFE PARALLELISM — enumerate all actionable issues, then admit them
-through `.squad/skills/squad-issue-drain/PROMPT.md`. Reserve waves of five or
-lower confirmed capacity. Launch one reserved member per exact 10-second
+through `.squad/skills/squad-issue-drain/PROMPT.md`. Prepare waves of five or
+lower confirmed capacity. Launch one prepared member per exact 10-second
 boundary without sleeping and without waiting for each individual ACK.
 
 ### Issue Selection
 
 Work on every open, unblocked, unassigned issue labeled `squad` or `squad:{member}`.
 Skip issues that are assigned to a human, blocked, or marked `status:on-hold`.
-Before creating a child, atomically reserve its issue. A failed/ambiguous
-creation, changed eligibility, lost capacity, or closed safety gate stops the
+Immediately before creating a child, run the single-coordinator process guard
+and best-effort repository reconciliation across sessions, branches, worktrees,
+PRs, reservations/ledger, and issue readiness. A failed/ambiguous creation,
+changed eligibility, lost capacity, or closed safety gate stops the
 remainder of the wave. Keep every successfully created child owned and paused
 until all such children return valid ACKs. Missing, negative, or corrupt ACKs
 block the next wave; inspect once after five minutes and never replace an

--- a/.squad/skills/squad-issue-drain/PROMPT.md
+++ b/.squad/skills/squad-issue-drain/PROMPT.md
@@ -1,18 +1,18 @@
 # Squad Issue Drain MVP Prompt
 
-**PROMPT_VERSION:** `squad-issue-drain/0.4.0`
+**PROMPT_VERSION:** `squad-issue-drain/0.5.0`
 
 You are the backlog orchestrator for a GitHub repository. Work continuously
 through ready issues by coordinating local and cloud child sessions.
 
-On every start and restart, reconcile GitHub, sessions, branches, worktrees, and
-PRs before starting anything new. Writer operation requires a verified,
-repository-scoped atomic lease or conditional-create/CAS capability supplied by
-the existing runtime. `squad_state_write`, conventions, a session-local ledger,
-and prose that says "one orchestrator" are not atomic ownership. If tool
-discovery cannot prove the required capability, remain read-only: Section 0 may
-permit queue enumeration, status, and classification, but no lease, spawn,
-admission, fallback, issue/PR mutation, or child release.
+On every start and restart, use the **single-coordinator process guard**. It
+performs **best-effort repository reconciliation** across GitHub, current
+sessions, branches, worktrees, PRs, runtime reservations, the session ledger,
+and issue readiness before starting anything new. It is deliberately a
+single-coordinator mechanism, not distributed mutual exclusion or cross-process
+exclusivity. Missing atomic CAS, lease, or conditional-create capability does
+not block enumeration, writer admission, mutation, retrospective completion, or
+child release. Incomplete or conflicting reconciliation still fails closed.
 
 ## Defaults
 
@@ -69,23 +69,27 @@ other prompt or template may bypass it.
    timestamps. GitHub evidence must be a current snapshot observed no more than
    five minutes before completion, and shipped/open item identities must be
    disjoint. Missing, stale, or inconsistent evidence fails closed.
-7. Before completion begins, reconcile and quiesce generic Scribe activity.
-   While exclusive retrospective completion is active, do not spawn generic
+7. Before completion begins, run the single-coordinator process guard, reconcile
+   all repository/runtime sources, and quiesce generic Scribe activity. While
+   dedicated retrospective completion is active, do not spawn generic
    Scribe work. If an existing generic Scribe cannot be proven finished, stop.
-8. The orchestrator must not write `log/` directly. Only when the runtime
-   advertises and verifies repository-scoped atomic conditional-create for the
-   canonical key may the returned key/content be handed to exclusive Scribe.
-   Plain `squad_state_write` is insufficient. Without that capability,
-   completion remains read-only and admission stays blocked.
-9. Exclusive Scribe performs exactly one conditional-create attempt. A conflict
-   is failure, not overwrite or success. Do not write a generic ceremony,
-   session, orchestration, decision, history, or health log in this mode.
-   Re-list and re-read the key before resuming queue work.
+8. The orchestrator must not write `log/` directly. Hand the deterministic
+   canonical key/content to the dedicated Scribe only after a complete listing
+   confirms the key is absent. Scribe performs one `squad_state_write`, then
+   re-lists and re-reads the key. If the exact valid record already exists,
+   reuse it idempotently without another write.
+9. A pre-write conflict, different read-back content, incomplete enumeration, or
+   uncertain result is failure, not permission to overwrite. After uncertainty,
+   re-list and re-read: exact valid content is success; missing or different
+   content remains blocked and is escalated through governed state recovery.
+   Do not write a generic ceremony, session, orchestration, decision, history,
+   or health log in this mode. Resume only after exact read-back succeeds.
 
-Scribe's verified conditional create is the final atomic ceremony step. An
-interrupted ceremony has no completion record and remains blocking. If
-interruption occurs after the create, the next round reuses that valid record
-and must not write another.
+The canonical write plus exact read-back is the final ceremony step. An
+interrupted ceremony with no valid record remains blocking. If interruption
+occurs after the write, the next round reuses that valid record and must not
+write another. This is idempotent under the single-coordinator process guard,
+but does not claim cross-process safety.
 Never hand-write runtime state, use git notes, overwrite an existing key, or
 create a second log for a cycle. Follow
 `docs/operations/weekly-retrospective.md` for ownership and recovery.
@@ -97,11 +101,12 @@ create a second log for a cycle. Follow
 - Do not duplicate existing sessions, branches, worktrees, or PRs.
 - Run Section 0 before every enumeration, status, classification, or admission
   path. Read-only output must be labeled read-only.
-- Do not claim writer exclusivity without verified repository-scoped atomic
-  lease or conditional-create/CAS support from the existing runtime.
+- Run the single-coordinator process guard before every writer operation; treat
+  incomplete or conflicting best-effort repository reconciliation as blocking.
 - Start independent work from freshly verified `origin/main`.
 - Start dependent work from its freshly verified remote parent branch.
-- Stop on dirty state, changed remote tips, conflicts, or lease uncertainty.
+- Stop on dirty state, changed remote tips, conflicts, or reconciliation
+  uncertainty.
 - Prefer `kickoff.agent: "Squad"` for child sessions when supported.
 - Open a draft PR only after the first coherent commit and applicable local
   validation pass.
@@ -179,12 +184,12 @@ issue | child session | location | branch/worktree | PR | state | last update
 
 Build one wave of at most five independent `READY` issues, capped by lower
 verified App capacity and every safety gate. Allocate a stable wave/batch ID and
-one stable admission token per issue. Before any child creation, reserve every
-selected issue under the verified repository-scoped atomic owner and record the
-reservation in the ledger. A candidate without a current unique reservation is
-not part of the wave and must not be created.
+one stable admission token per issue, then record the prepared candidates in the
+session ledger. These entries are correlation evidence, not cross-process
+ownership. A candidate without a current unique ledger entry is not part of the
+wave and must not be created.
 
-Every successfully created child starts paused. Launch the next reserved member
+Every successfully created child starts paused. Launch the next prepared member
 of the same wave without waiting for the preceding child's ACK. Do not release a
 child after its individual ACK. The spawn phase must first complete or stop, and
 then every successfully created child must return a valid correlated ACK before
@@ -193,14 +198,18 @@ any created child is released or another wave can begin.
 Before each spawn attempt:
 
 1. Reconfirm the weekly retrospective admission check is current.
-2. Reconfirm the verified repository-scoped atomic ownership capability and
-   current coordinator ownership. If unavailable or lost, stop all remaining
-   spawn attempts and stay read-only.
+2. Rerun the single-coordinator process guard at the current timestamp. Complete
+   best-effort repository reconciliation must cover sessions, branches,
+   worktrees, PRs, runtime reservations, the session ledger, and issue readiness.
+   If any source is unavailable, stale, duplicated, or conflicting, stop all
+   remaining spawn attempts.
 3. Confirm the issue is still `READY`.
-4. Confirm no session, branch, worktree, or PR already owns it.
-5. Confirm the issue does not collide with active writers.
-6. Confirm lower verified capacity still exists.
-7. Confirm the issue still has its unique wave reservation.
+4. Confirm no session, branch, worktree, or PR already represents it.
+5. Confirm reservations and ledger records correlate to this coordinator,
+   batch, issue, and admission token, with no competing record.
+6. Confirm the issue does not collide with active writers.
+7. Confirm lower verified capacity still exists and the prepared ledger entry
+   remains unique.
 8. At the exact 10-second boundary after the prior spawn attempt, including a
    failed attempt or local fallback attempt, create exactly one child session
    with the preallocated admission token. A delayed wake may attempt immediately
@@ -210,7 +219,7 @@ Before each spawn attempt:
 
 If creation is ambiguous, definitively fails, eligibility changes, capacity is
 lost, or any safety gate closes, immediately stop launching the remainder of
-the wave. Record the current disposition and mark later reservations unlaunched;
+the wave. Record the current disposition and mark later entries unlaunched;
 do not create a replacement. Keep every successfully created child owned,
 paused, and awaiting its ACK. A definitively failed cloud creation may use its
 single same-token local fallback after the next 10-second boundary, but no other
@@ -241,7 +250,7 @@ ACK with `ready: false`, a non-clear check, or a blocker is a negative ACK.
 Either disposition keeps all created children paused and blocks the next wave.
 
 The barrier covers all and only successfully created children; failed,
-ambiguous, ineligible, and unlaunched reservations do not manufacture ACKs.
+ambiguous, ineligible, and unlaunched entries do not manufacture ACKs.
 Require an explicit valid ACK from every successfully created child. A normally
 completed wave may then release all created children and advance. A stopped
 partial wave with all created-child ACKs valid may release those children, but
@@ -362,7 +371,7 @@ Next action: action or NEXT_TICK_REQUIRED
 Repeat:
 
 ```text
-Section 0 -> scan -> classify -> reserve wave -> pace wave spawns
+Section 0 -> scan -> classify -> prepare wave -> pace wave spawns
 -> all successfully created child ACKs -> release eligible created children
 -> monitor -> report -> Section 0 -> rescan
 ```

--- a/.squad/skills/squad-issue-drain/SKILL.md
+++ b/.squad/skills/squad-issue-drain/SKILL.md
@@ -9,12 +9,12 @@ contract.
 
 Start with the fail-closed defaults:
 
-- writer operation only with verified existing repository-scoped atomic
-  ownership; otherwise read-only;
+- writer operation only after the single-coordinator process guard completes
+  best-effort repository reconciliation; otherwise blocked;
 - waves of up to five App child issue sessions, capped by lower verified
   capacity;
 - one issue, owner, session, branch/worktree, and PR;
-- reserve each selected issue before creation and wait exactly 10 seconds
+- prepare each selected issue in the session ledger and wait exactly 10 seconds
   between all spawn attempts without sleeping inside a turn;
 - continue same-wave launches without waiting for individual ACKs, then require
   a correlated valid ACK from every successfully created child before release
@@ -32,4 +32,6 @@ in `PROMPT.md`. It uses runtime state tools and remains active when the optional
 `retro-enforcement` component is missing.
 
 Always render the ready/active/blocked issue tree before starting work. Reconcile
-existing sessions, branches, worktrees, and PRs before every new admission.
+sessions, branches, worktrees, PRs, reservations/ledger, and issue readiness
+immediately before every spawn. The guard does not claim cross-process
+exclusivity.

--- a/.squad/skills/squad-issue-drain/issue-drain.js
+++ b/.squad/skills/squad-issue-drain/issue-drain.js
@@ -8,6 +8,27 @@ const QUEUE_OPERATIONS = new Set([
   'status',
   'classify',
   'admit',
+  'mutate',
+  'release',
+]);
+const WRITER_OPERATIONS = new Set(['admit', 'mutate', 'release']);
+const RECONCILIATION_COLLECTIONS = [
+  'sessions',
+  'branches',
+  'worktrees',
+  'pullRequests',
+  'reservations',
+  'ledger',
+  'issueReadiness',
+];
+const INACTIVE_STATES = new Set([
+  'archived',
+  'closed',
+  'failed',
+  'ineligible',
+  'merged',
+  'released',
+  'unlaunched',
 ]);
 
 function validDate(value) {
@@ -40,69 +61,165 @@ function positiveInteger(value) {
 function writerAuthorizationCurrent(sectionZero, now, batchId = null) {
   const current = validDate(now);
   const checkedAt = validDate(sectionZero?.checkedAt);
-  const validUntil = validDate(sectionZero?.authorization?.validUntil);
   return Boolean(
     sectionZero?.allowed === true
     && sectionZero.mode === 'writer'
+    && sectionZero.authorization?.mechanism === 'single-coordinator-process-guard'
     && current !== null
     && checkedAt === current
-    && validUntil !== null
-    && current < validUntil
     && (batchId === null || sectionZero.authorization.batchId === batchId),
   );
 }
 
-function assessAtomicOwnership(capability, {
+function activeRecord(record) {
+  return record?.active !== false
+    && !INACTIVE_STATES.has(String(record?.state || '').toLowerCase());
+}
+
+function assessSingleCoordinatorProcessGuard(reconciliation, {
   now,
   repository,
-  ownerId,
+  coordinatorId,
+  batchId = null,
+  issue = null,
+  admissionToken = null,
 } = {}) {
-  if (!capability || typeof capability !== 'object' || Array.isArray(capability)) {
-    return { available: false, mode: 'read-only', reason: 'atomic-ownership-unavailable' };
+  const current = validDate(now);
+  const checkedAt = validDate(reconciliation?.checkedAt);
+  const shapeValid = reconciliation
+    && typeof reconciliation === 'object'
+    && !Array.isArray(reconciliation)
+    && reconciliation.complete === true
+    && reconciliation.repository === repository
+    && /^[^/\s]+\/[^/\s]+$/.test(repository || '')
+    && typeof coordinatorId === 'string'
+    && coordinatorId.trim()
+    && current !== null
+    && checkedAt === current
+    && RECONCILIATION_COLLECTIONS.every(
+      (name) => Array.isArray(reconciliation[name]),
+    );
+  if (!shapeValid) {
+    return {
+      available: false,
+      mode: 'blocked',
+      reason: 'repository-reconciliation-incomplete',
+    };
   }
 
-  const common =
-    capability.verified === true
-    && capability.repositoryScoped === true
-    && capability.repository === repository
-    && capability.ownerId === ownerId
-    && typeof capability.grantId === 'string'
-    && capability.grantId.length > 0
-    && typeof capability.tool === 'string'
-    && capability.tool.length > 0;
-  const lease =
-    capability.kind === 'lease'
-    && capability.acquire === true
-    && capability.renew === true
-    && capability.release === true;
-  const conditionalCreate =
-    capability.kind === 'conditional-create'
-    && capability.createIfAbsent === true
-    && capability.conflictIsFailure === true;
+  const records = RECONCILIATION_COLLECTIONS
+    .flatMap((name) => reconciliation[name].map((record) => ({ name, record })));
+  if (records.some(({ record }) =>
+    !record
+    || typeof record !== 'object'
+    || Array.isArray(record)
+    || !positiveInteger(record.issue))) {
+    return {
+      available: false,
+      mode: 'blocked',
+      reason: 'repository-reconciliation-invalid',
+    };
+  }
 
-  const current = validDate(now);
-  const verifiedAt = validDate(capability.verifiedAt);
-  const validUntil = validDate(capability.validUntil);
-  const currentGrant = current !== null
-    && verifiedAt !== null
-    && validUntil !== null
-    && verifiedAt <= current
-    && current < validUntil;
+  for (const name of ['sessions', 'branches', 'worktrees', 'pullRequests']) {
+    const activeIssues = reconciliation[name]
+      .filter(activeRecord)
+      .map((record) => record.issue);
+    if (new Set(activeIssues).size !== activeIssues.length) {
+      return {
+        available: false,
+        mode: 'blocked',
+        reason: 'duplicate-reconciliation-conflict',
+        source: name,
+      };
+    }
+  }
 
-  if (!common || !currentGrant || (!lease && !conditionalCreate)) {
-    return { available: false, mode: 'read-only', reason: 'atomic-ownership-unavailable' };
+  const activeCoordination = [
+    ...reconciliation.reservations,
+    ...reconciliation.ledger,
+  ].filter(activeRecord);
+  const foreign = activeCoordination.find(
+    (record) => record.coordinatorId !== coordinatorId,
+  );
+  if (foreign) {
+    return {
+      available: false,
+      mode: 'blocked',
+      reason: 'coordinator-reconciliation-conflict',
+      issue: foreign.issue,
+    };
+  }
+
+  const readiness = new Map();
+  for (const record of reconciliation.issueReadiness) {
+    if (readiness.has(record.issue)) {
+      return {
+        available: false,
+        mode: 'blocked',
+        reason: 'issue-readiness-duplicate',
+        issue: record.issue,
+      };
+    }
+    readiness.set(record.issue, record.ready === true);
+  }
+  const occupiedIssues = new Set(
+    ['sessions', 'branches', 'worktrees', 'pullRequests']
+      .flatMap((name) => reconciliation[name])
+      .filter(activeRecord)
+      .map((record) => record.issue),
+  );
+
+  if (issue !== null) {
+    if (!positiveInteger(issue) || readiness.get(issue) !== true) {
+      return {
+        available: false,
+        mode: 'blocked',
+        reason: 'issue-eligibility-changed',
+        issue,
+      };
+    }
+    if (occupiedIssues.has(issue)) {
+      return {
+        available: false,
+        mode: 'blocked',
+        reason: 'issue-already-active',
+        issue,
+      };
+    }
+    for (const name of ['reservations', 'ledger']) {
+      const matching = reconciliation[name]
+        .filter(activeRecord)
+        .filter((record) => record.issue === issue);
+      if (matching.length > 1 || matching.some((record) =>
+        record.coordinatorId !== coordinatorId
+        || (batchId !== null && record.batchId !== batchId)
+        || (admissionToken !== null && record.admissionToken !== admissionToken))) {
+        return {
+          available: false,
+          mode: 'blocked',
+          reason: 'admission-reconciliation-conflict',
+          source: name,
+          issue,
+        };
+      }
+    }
   }
 
   return {
     available: true,
     mode: 'writer',
-    reason: 'atomic-ownership-verified',
-    kind: capability.kind,
-    tool: capability.tool,
+    reason: 'single-coordinator-process-guard-clear',
+    mechanism: 'single-coordinator-process-guard',
+    checkedAt: new Date(current).toISOString(),
+    guardId: `${repository}:${coordinatorId}:${new Date(current).toISOString()}`,
     repository,
-    ownerId,
-    grantId: capability.grantId,
-    validUntil: new Date(validUntil).toISOString(),
+    coordinatorId,
+    readyIssues: [...readiness.entries()]
+      .filter(([, ready]) => ready)
+      .map(([readyIssue]) => readyIssue)
+      .sort((left, right) => left - right),
+    occupiedIssues: [...occupiedIssues].sort((left, right) => left - right),
   };
 }
 
@@ -111,10 +228,10 @@ function assessSectionZero({
   stateAvailable = false,
   enumerationComplete = false,
   retrospectiveAllowed = false,
-  ownershipCapability,
+  reconciliation,
   now,
   repository,
-  ownerId,
+  coordinatorId,
   batchId,
 }) {
   if (!QUEUE_OPERATIONS.has(operation)) {
@@ -130,32 +247,35 @@ function assessSectionZero({
     return { allowed: false, mode: 'blocked', reason: 'retrospective-not-current' };
   }
 
-  const ownership = assessAtomicOwnership(ownershipCapability, {
-    now,
-    repository,
-    ownerId,
-  });
-  if (!ownership.available) {
-    if (operation === 'admit') {
-      return { allowed: false, mode: 'read-only', reason: ownership.reason };
-    }
-    return { allowed: true, mode: 'read-only', reason: ownership.reason };
+  if (!WRITER_OPERATIONS.has(operation)) {
+    return { allowed: true, mode: 'read-only', reason: 'section-zero-passed' };
   }
 
-  if (operation === 'admit' && (typeof batchId !== 'string' || !batchId.trim())) {
+  if (typeof batchId !== 'string' || !batchId.trim()) {
     return { allowed: false, mode: 'blocked', reason: 'batch-id-required' };
+  }
+  const guard = assessSingleCoordinatorProcessGuard(reconciliation, {
+    now,
+    repository,
+    coordinatorId,
+    batchId,
+  });
+  if (!guard.available) {
+    return { allowed: false, mode: 'blocked', reason: guard.reason };
   }
   return {
     allowed: true,
     mode: 'writer',
     reason: 'section-zero-passed',
-    checkedAt: new Date(validDate(now)).toISOString(),
+    checkedAt: guard.checkedAt,
     authorization: {
-      repository: ownership.repository,
-      ownerId: ownership.ownerId,
-      grantId: ownership.grantId,
-      validUntil: ownership.validUntil,
-      batchId: operation === 'admit' ? batchId : null,
+      mechanism: guard.mechanism,
+      guardId: guard.guardId,
+      repository: guard.repository,
+      coordinatorId: guard.coordinatorId,
+      readyIssues: guard.readyIssues,
+      occupiedIssues: guard.occupiedIssues,
+      batchId,
     },
   };
 }
@@ -197,26 +317,31 @@ function createBatch({
       || new Set(selected.map((candidate) => candidate.admissionToken)).size !== selected.length) {
     return { ready: false, reason: 'candidate-correlation-duplicate', batch: null };
   }
+  if (selected.some((candidate) =>
+    !sectionZero.authorization.readyIssues.includes(candidate.issue)
+    || sectionZero.authorization.occupiedIssues.includes(candidate.issue))) {
+    return { ready: false, reason: 'candidate-reconciliation-conflict', batch: null };
+  }
 
-  const reservedAt = new Date(validDate(now)).toISOString();
+  const preparedAt = new Date(validDate(now)).toISOString();
   return {
     ready: true,
-    reason: 'wave-reserved',
+    reason: 'wave-prepared',
     batch: {
       id: batchId,
       limit,
       authorization: { ...sectionZero.authorization },
       launchState: 'launching',
-      reservedAt,
+      preparedAt,
       launchClosedAt: null,
       stopReason: null,
       ackInspectionAt: null,
       admissions: selected.map((candidate) => ({
         ...candidate,
         batchId,
-        reservationId: candidate.admissionToken,
-        state: 'reserved',
-        reservedAt,
+        guardToken: candidate.admissionToken,
+        state: 'prepared',
+        preparedAt,
         attemptedAt: null,
         createdAt: null,
       })),
@@ -235,6 +360,7 @@ function assessSpawnAttempt({
   issueReady = false,
   capacityAvailable = false,
   creationOutcome = 'not-started',
+  reconciliation,
 }) {
   if (!writerAuthorizationCurrent(sectionZero, now, batchId)) {
     return { allowed: false, reason: 'writer-admission-not-authorized' };
@@ -251,13 +377,24 @@ function assessSpawnAttempt({
   if (capacityAvailable !== true) {
     return { allowed: false, reason: 'verified-capacity-unavailable' };
   }
+  const guard = assessSingleCoordinatorProcessGuard(reconciliation, {
+    now,
+    repository: sectionZero.authorization.repository,
+    coordinatorId: sectionZero.authorization.coordinatorId,
+    batchId,
+    issue: admission?.issue,
+    admissionToken: admission?.admissionToken,
+  });
+  if (!guard.available) {
+    return { allowed: false, reason: guard.reason };
+  }
   if (!admission
       || admission.batchId !== batchId
-      || admission.state !== 'reserved'
-      || admission.reservationId !== admission.admissionToken
+      || admission.state !== 'prepared'
+      || admission.guardToken !== admission.admissionToken
       || typeof admission.admissionToken !== 'string'
       || !admission.admissionToken) {
-    return { allowed: false, reason: 'issue-reservation-invalid' };
+    return { allowed: false, reason: 'issue-guard-token-invalid' };
   }
   if (!['not-started', 'definitive-non-creation'].includes(creationOutcome)) {
     return { allowed: false, reason: 'creation-outcome-ambiguous' };
@@ -302,14 +439,14 @@ function recordCreationOutcome({
     (admission) => admission.admissionToken === admissionToken,
   );
   if (index < 0) {
-    return { recorded: false, reason: 'reservation-not-found', batch: null };
+    return { recorded: false, reason: 'admission-not-found', batch: null };
   }
 
   const current = batch.admissions[index];
-  const stateAllowed = current.state === 'reserved'
+  const stateAllowed = current.state === 'prepared'
     || (fallback === true && current.state === 'failed');
   if (!stateAllowed) {
-    return { recorded: false, reason: 'reservation-already-resolved', batch: null };
+    return { recorded: false, reason: 'admission-already-resolved', batch: null };
   }
   const supported = new Set([
     'created',
@@ -322,9 +459,9 @@ function recordCreationOutcome({
   if (!supported.has(outcome)) {
     return { recorded: false, reason: 'creation-outcome-invalid', batch: null };
   }
-  const reserved = validDate(current.reservedAt);
-  if (reserved === null || attempt < reserved) {
-    return { recorded: false, reason: 'attempt-precedes-reservation', batch: null };
+  const prepared = validDate(current.preparedAt);
+  if (prepared === null || attempt < prepared) {
+    return { recorded: false, reason: 'attempt-precedes-admission', batch: null };
   }
   if (['created', 'definitive-non-creation', 'uncertain'].includes(outcome)) {
     const previousAttempts = batch.admissions
@@ -356,7 +493,7 @@ function recordCreationOutcome({
       createdAt: admission.attemptedAt,
     });
     if (next.launchState !== 'stopped'
-        && next.admissions.every((item) => item.state !== 'reserved')) {
+        && next.admissions.every((item) => item.state !== 'prepared')) {
       next.launchState = 'complete';
       next.launchClosedAt = admission.attemptedAt;
     }
@@ -372,7 +509,7 @@ function recordCreationOutcome({
   };
   admission.state = stateByOutcome[outcome];
   for (let remaining = index + 1; remaining < next.admissions.length; remaining += 1) {
-    if (next.admissions[remaining].state === 'reserved') {
+    if (next.admissions[remaining].state === 'prepared') {
       next.admissions[remaining].state = 'unlaunched';
     }
   }
@@ -476,13 +613,11 @@ function assessBatchAdvance({
   const batchAuthorization = batch.authorization;
   const authorizationCurrent =
     validDate(sectionZero.checkedAt) === current
-    && validDate(authorization?.validUntil) !== null
-    && current < validDate(authorization.validUntil)
+    && authorization?.mechanism === 'single-coordinator-process-guard'
     && authorization?.batchId === batch.id
     && batchAuthorization?.batchId === batch.id
     && authorization?.repository === batchAuthorization?.repository
-    && authorization?.ownerId === batchAuthorization?.ownerId
-    && authorization?.grantId === batchAuthorization?.grantId;
+    && authorization?.coordinatorId === batchAuthorization?.coordinatorId;
   if (!authorizationCurrent) {
     return {
       allowed: false,
@@ -648,10 +783,10 @@ module.exports = {
   ACK_TIMEOUT_MILLISECONDS,
   MAX_BATCH_SIZE,
   MIN_SPAWN_SPACING_MILLISECONDS,
-  assessAtomicOwnership,
   assessBatchAdvance,
   assessLocalFallback,
   assessSectionZero,
+  assessSingleCoordinatorProcessGuard,
   assessSpawnAttempt,
   createBatch,
   mergeDisposition,

--- a/.squad/skills/squad-issue-drain/issue-drain.test.js
+++ b/.squad/skills/squad-issue-drain/issue-drain.test.js
@@ -8,10 +8,10 @@ const {
   ACK_TIMEOUT_MILLISECONDS,
   MAX_BATCH_SIZE,
   MIN_SPAWN_SPACING_MILLISECONDS,
-  assessAtomicOwnership,
   assessBatchAdvance,
   assessLocalFallback,
   assessSectionZero,
+  assessSingleCoordinatorProcessGuard,
   assessSpawnAttempt,
   createBatch,
   mergeDisposition,
@@ -21,34 +21,49 @@ const {
 } = require('./issue-drain');
 
 const now = '2026-08-29T19:00:00.000Z';
-const writerCapability = {
-  verified: true,
-  repositoryScoped: true,
-  repository: 'Jamula/Andreja',
-  ownerId: 'coordinator-1',
-  grantId: 'grant-1',
-  verifiedAt: '2026-08-29T18:00:00.000Z',
-  validUntil: '2026-08-29T20:00:00.000Z',
-  kind: 'conditional-create',
-  tool: 'runtime.conditionalCreate',
-  createIfAbsent: true,
-  conflictIsFailure: true,
-};
+
+function repositoryReconciliation({
+  checkedAt = now,
+  sessions = [],
+  branches = [],
+  worktrees = [],
+  pullRequests = [],
+  reservations = [],
+  ledger = [],
+  issueReadiness = [1, 2, 3, 4, 5, 6, 7, 132]
+    .map((issue) => ({ issue, ready: true })),
+  ...overrides
+} = {}) {
+  return {
+    repository: 'Jamula/Andreja',
+    checkedAt,
+    complete: true,
+    sessions,
+    branches,
+    worktrees,
+    pullRequests,
+    reservations,
+    ledger,
+    issueReadiness,
+    ...overrides,
+  };
+}
 
 function writerSection(
   operation = 'admit',
   checkedAt = now,
   batchId = 'batch-1',
+  reconciliation = repositoryReconciliation({ checkedAt }),
 ) {
   return assessSectionZero({
     operation,
     stateAvailable: true,
     enumerationComplete: true,
     retrospectiveAllowed: true,
-    ownershipCapability: writerCapability,
+    reconciliation,
     now: checkedAt,
     repository: 'Jamula/Andreja',
-    ownerId: 'coordinator-1',
+    coordinatorId: 'coordinator-1',
     batchId,
   });
 }
@@ -77,18 +92,18 @@ function ackFor(expected, override = {}) {
   };
 }
 
-function reserveBatch(
+function prepareBatch(
   issues = [1, 2],
   batchId = 'batch-1',
   verifiedCapacity = 5,
-  reservedAt = '2026-08-29T18:59:00.000Z',
+  preparedAt = '2026-08-29T18:59:00.000Z',
 ) {
   const result = createBatch({
     batchId,
     candidates: issues.map(admission),
     verifiedCapacity,
-    sectionZero: writerSection('admit', reservedAt, batchId),
-    now: reservedAt,
+    sectionZero: writerSection('admit', preparedAt, batchId),
+    now: preparedAt,
   });
   assert.equal(result.ready, true);
   return result.batch;
@@ -129,61 +144,141 @@ function closeCreatedWave(batch, attemptedAt = now) {
   }, batch);
 }
 
-test('atomic ownership must be explicit, scoped, current, and verified', () => {
-  assert.deepEqual(assessAtomicOwnership(), {
+test('single-coordinator process guard requires complete current repository reconciliation', () => {
+  assert.deepEqual(assessSingleCoordinatorProcessGuard(), {
     available: false,
-    mode: 'read-only',
-    reason: 'atomic-ownership-unavailable',
+    mode: 'blocked',
+    reason: 'repository-reconciliation-incomplete',
   });
-  for (const override of [
-    { verified: false },
-    { repositoryScoped: false },
-    { createIfAbsent: false },
-    { conflictIsFailure: false },
-    { repository: 'other/repository' },
-    { ownerId: 'other-owner' },
-    { grantId: '' },
-    { validUntil: now },
+  for (const reconciliation of [
+    repositoryReconciliation({ complete: false }),
+    repositoryReconciliation({ repository: 'other/repository' }),
+    repositoryReconciliation({ checkedAt: '2026-08-29T18:59:59.999Z' }),
+    repositoryReconciliation({ sessions: null }),
   ]) {
     assert.equal(
-      assessAtomicOwnership(
-        { ...writerCapability, ...override },
-        { now, repository: 'Jamula/Andreja', ownerId: 'coordinator-1' },
+      assessSingleCoordinatorProcessGuard(
+        reconciliation,
+        { now, repository: 'Jamula/Andreja', coordinatorId: 'coordinator-1' },
       ).available,
       false,
     );
   }
-  assert.equal(assessAtomicOwnership(
-    writerCapability,
-    { now, repository: 'Jamula/Andreja', ownerId: 'coordinator-1' },
+  assert.equal(assessSingleCoordinatorProcessGuard(
+    repositoryReconciliation(),
+    { now, repository: 'Jamula/Andreja', coordinatorId: 'coordinator-1' },
   ).available, true);
 });
 
-test('the installed runtime exposes no atomic ownership tool and therefore stays read-only', () => {
-  const root = path.resolve(__dirname, '../../..');
-  const config = JSON.parse(fs.readFileSync(path.join(root, '.mcp.json'), 'utf8'));
-  const tools = config.mcpServers.squad_state.tools;
-  assert.equal(
-    tools.some((name) => /lease|compare|conditional|create.?if.?absent/i.test(name)),
-    false,
-  );
+test('process guard blocks duplicate artifacts and competing coordinator evidence', () => {
+  assert.equal(assessSingleCoordinatorProcessGuard(
+    repositoryReconciliation({
+      sessions: [
+        { issue: 1, state: 'running' },
+        { issue: 1, state: 'running' },
+      ],
+    }),
+    { now, repository: 'Jamula/Andreja', coordinatorId: 'coordinator-1' },
+  ).reason, 'duplicate-reconciliation-conflict');
+
+  for (const [source, record] of [
+    ['sessions', { issue: 1, state: 'running' }],
+    ['branches', { issue: 1, state: 'open' }],
+    ['worktrees', { issue: 1, state: 'active' }],
+    ['pullRequests', { issue: 1, state: 'open' }],
+  ]) {
+    const result = assessSingleCoordinatorProcessGuard(
+      repositoryReconciliation({ [source]: [record] }),
+      {
+        now,
+        repository: 'Jamula/Andreja',
+        coordinatorId: 'coordinator-1',
+        batchId: 'batch-1',
+        issue: 1,
+        admissionToken: 'batch-1:1',
+      },
+    );
+    assert.equal(result.reason, 'issue-already-active', source);
+  }
+
+  for (const source of ['reservations', 'ledger']) {
+    const result = assessSingleCoordinatorProcessGuard(
+      repositoryReconciliation({
+        [source]: [{
+          issue: 1,
+          state: 'active',
+          coordinatorId: 'coordinator-2',
+          batchId: 'other-batch',
+          admissionToken: 'other-token',
+        }],
+      }),
+      { now, repository: 'Jamula/Andreja', coordinatorId: 'coordinator-1' },
+    );
+    assert.equal(result.reason, 'coordinator-reconciliation-conflict', source);
+  }
+});
+
+test('spawn re-runs best-effort repository reconciliation immediately before creation', () => {
+  const batch = prepareBatch([1]);
+  const base = {
+    now,
+    previousAttemptAt: null,
+    sectionZero: writerSection(),
+    batchId: batch.id,
+    admission: batch.admissions[0],
+    duplicateCheck: true,
+    collisionCheck: true,
+    issueReady: true,
+    capacityAvailable: true,
+  };
+  assert.equal(assessSpawnAttempt({
+    ...base,
+    reconciliation: repositoryReconciliation({
+      sessions: [{ issue: 1, state: 'running' }],
+    }),
+  }).reason, 'issue-already-active');
+  assert.equal(assessSpawnAttempt({
+    ...base,
+    reconciliation: repositoryReconciliation({
+      issueReadiness: [{ issue: 1, ready: false }],
+    }),
+  }).reason, 'issue-eligibility-changed');
+});
+
+test('writer admission does not depend on atomic runtime capabilities', () => {
   assert.deepEqual(assessSectionZero({
     operation: 'admit',
     stateAvailable: true,
     enumerationComplete: true,
     retrospectiveAllowed: true,
+    now,
+    repository: 'Jamula/Andreja',
+    coordinatorId: 'coordinator-1',
+    batchId: 'batch-1',
+    reconciliation: repositoryReconciliation(),
   }), {
-    allowed: false,
-    mode: 'read-only',
-    reason: 'atomic-ownership-unavailable',
+    allowed: true,
+    mode: 'writer',
+    reason: 'section-zero-passed',
+    checkedAt: now,
+    authorization: {
+      mechanism: 'single-coordinator-process-guard',
+      guardId: `Jamula/Andreja:coordinator-1:${now}`,
+      repository: 'Jamula/Andreja',
+      coordinatorId: 'coordinator-1',
+      readyIssues: [1, 2, 3, 4, 5, 6, 7, 132],
+      occupiedIssues: [],
+      batchId: 'batch-1',
+    },
   });
 });
 
 test('Section 0 is mandatory for every queue operation', () => {
-  for (const operation of ['enumerate', 'status', 'classify', 'admit']) {
+  for (const operation of ['enumerate', 'status', 'classify', 'admit', 'mutate', 'release']) {
     assert.equal(assessSectionZero({ operation }).allowed, false);
     assert.equal(writerSection(operation).allowed, true);
   }
+  assert.equal(writerSection('status').mode, 'read-only');
   assert.equal(assessSectionZero({
     operation: 'status',
     stateAvailable: true,
@@ -202,12 +297,12 @@ test('batch size is five and lower verified capacity overrides it', () => {
     now,
   });
   assert.equal(MAX_BATCH_SIZE, 5);
-  assert.equal(full.reason, 'wave-reserved');
+  assert.equal(full.reason, 'wave-prepared');
   assert.equal(full.batch.admissions.length, 5);
   assert.equal(full.batch.launchState, 'launching');
   assert.ok(full.batch.admissions.every(
-    (item) => item.state === 'reserved'
-      && item.reservationId === item.admissionToken,
+    (item) => item.state === 'prepared'
+      && item.guardToken === item.admissionToken,
   ));
 
   const lower = createBatch({
@@ -222,7 +317,7 @@ test('batch size is five and lower verified capacity overrides it', () => {
 });
 
 test('spawn attempts require ten elapsed seconds and all safety checks', () => {
-  const batch = reserveBatch([1]);
+  const batch = prepareBatch([1]);
   const base = {
     now,
     previousAttemptAt: '2026-08-29T18:59:50.001Z',
@@ -233,6 +328,7 @@ test('spawn attempts require ten elapsed seconds and all safety checks', () => {
     collisionCheck: true,
     issueReady: true,
     capacityAvailable: true,
+    reconciliation: repositoryReconciliation(),
   };
   assert.equal(MIN_SPAWN_SPACING_MILLISECONDS, 10_000);
   assert.equal(ACK_TIMEOUT_MILLISECONDS, 300_000);
@@ -262,7 +358,7 @@ test('spawn attempts require ten elapsed seconds and all safety checks', () => {
       ...base,
       admission: { ...base.admission, state: 'created' },
     }).reason,
-    'issue-reservation-invalid',
+    'issue-guard-token-invalid',
   );
 });
 
@@ -295,7 +391,7 @@ test('ACKs are correlated to issue, admission token, ownership, and base', () =>
 });
 
 test('same-wave spawning continues without waiting for individual ACKs', () => {
-  let batch = reserveBatch([1, 2]);
+  let batch = prepareBatch([1, 2]);
   batch = recordCreated(
     batch,
     batch.admissions[0].admissionToken,
@@ -320,11 +416,12 @@ test('same-wave spawning continues without waiting for individual ACKs', () => {
     collisionCheck: true,
     issueReady: true,
     capacityAvailable: true,
+    reconciliation: repositoryReconciliation(),
   }).allowed, true);
 });
 
 test('every successfully created child ACK is required before wave advancement', () => {
-  const batch = closeCreatedWave(reserveBatch([1, 2, 3]));
+  const batch = closeCreatedWave(prepareBatch([1, 2, 3]));
   const pending = assessBatchAdvance({
     batch,
     acknowledgements: batch.admissions.slice(0, 2).map(ackFor),
@@ -340,7 +437,7 @@ test('every successfully created child ACK is required before wave advancement',
     batch,
     acknowledgements: batch.admissions.map(ackFor),
     now,
-    sectionZero: writerSection(),
+    sectionZero: writerSection('release'),
   });
   assert.equal(complete.allowed, true);
   assert.equal(complete.releaseChildren, true);
@@ -356,7 +453,7 @@ test('failed, ambiguous, or ineligible creation stops the remainder of a wave', 
     'capacity-lost',
     'safety-gate-failed',
   ]) {
-    let batch = reserveBatch([1, 2, 3]);
+    let batch = prepareBatch([1, 2, 3]);
     batch = recordCreated(
       batch,
       batch.admissions[0].admissionToken,
@@ -389,7 +486,7 @@ test('failed, ambiguous, or ineligible creation stops the remainder of a wave', 
 });
 
 test('stopped partial waves remain distinct from negative and corrupt ACKs', () => {
-  let batch = reserveBatch([1, 2, 3]);
+  let batch = prepareBatch([1, 2, 3]);
   batch = recordCreated(
     batch,
     batch.admissions[0].admissionToken,
@@ -425,7 +522,7 @@ test('stopped partial waves remain distinct from negative and corrupt ACKs', () 
 });
 
 test('a stopped wave with no created child cannot advance vacuously', () => {
-  let batch = reserveBatch([1, 2]);
+  let batch = prepareBatch([1, 2]);
   batch = recordCreationOutcome({
     batch,
     admissionToken: batch.admissions[0].admissionToken,
@@ -444,7 +541,7 @@ test('a stopped wave with no created child cannot advance vacuously', () => {
 });
 
 test('ACK timeout is derived from wave closure and inspected exactly once', () => {
-  let batch = closeCreatedWave(reserveBatch([1, 2]));
+  let batch = closeCreatedWave(prepareBatch([1, 2]));
   const acknowledgements = [ackFor(batch.admissions[0])];
   assert.equal(assessBatchAdvance({
     batch,
@@ -489,7 +586,7 @@ test('ACK timeout is derived from wave closure and inspected exactly once', () =
 });
 
 test('restart requires the same inspect-once path and never replacement', () => {
-  const batch = closeCreatedWave(reserveBatch([1, 2]));
+  const batch = closeCreatedWave(prepareBatch([1, 2]));
   const result = assessBatchAdvance({
     batch,
     acknowledgements: [ackFor(batch.admissions[0])],
@@ -503,7 +600,7 @@ test('restart requires the same inspect-once path and never replacement', () => 
 });
 
 test('batch release requires current writer authorization', () => {
-  const batch = closeCreatedWave(reserveBatch([1]));
+  const batch = closeCreatedWave(prepareBatch([1]));
   const result = assessBatchAdvance({
     batch,
     acknowledgements: batch.admissions.map(ackFor),
@@ -515,7 +612,7 @@ test('batch release requires current writer authorization', () => {
       retrospectiveAllowed: true,
       now,
       repository: 'Jamula/Andreja',
-      ownerId: 'coordinator-1',
+      coordinatorId: 'coordinator-1',
       batchId: 'batch-1',
     }),
   });
@@ -525,7 +622,7 @@ test('batch release requires current writer authorization', () => {
 });
 
 test('batch release rejects mismatched embedded batch identity', () => {
-  const valid = closeCreatedWave(reserveBatch([1]));
+  const valid = closeCreatedWave(prepareBatch([1]));
   for (const batch of [
     {
       ...valid,
@@ -561,7 +658,7 @@ test('batch creation and spawning reject stale or unbound writer authorization',
   }).ready, false);
 
   const statusAuthorization = writerSection('status');
-  const batch = reserveBatch([1]);
+  const batch = prepareBatch([1]);
   assert.equal(assessSpawnAttempt({
     now,
     previousAttemptAt: null,
@@ -572,11 +669,12 @@ test('batch creation and spawning reject stale or unbound writer authorization',
     collisionCheck: true,
     issueReady: true,
     capacityAvailable: true,
+    reconciliation: repositoryReconciliation(),
   }).allowed, false);
 });
 
 test('ambiguous creation blocks fallback and definitive non-creation permits one same-token fallback', () => {
-  const batch = reserveBatch([1]);
+  const batch = prepareBatch([1]);
   const cloudAttemptAt = '2026-08-29T18:59:50.000Z';
   const spawnAttempt = assessSpawnAttempt({
     now,
@@ -589,6 +687,7 @@ test('ambiguous creation blocks fallback and definitive non-creation permits one
     capacityAvailable: true,
     batchId: 'batch-1',
     creationOutcome: 'definitive-non-creation',
+    reconciliation: repositoryReconciliation(),
   });
   assert.equal(assessLocalFallback({
     admissionToken: batch.admissions[0].admissionToken,
@@ -624,7 +723,7 @@ test('ambiguous creation blocks fallback and definitive non-creation permits one
   }).reason, 'fallback-attempt-correlation-invalid');
 });
 
-test('writer timestamps require timezone-qualified RFC 3339 values', () => {
+test('process guard timestamps require timezone-qualified RFC 3339 values', () => {
   for (const malformed of [
     '2026-08-29',
     '2026-08-29T19:00:00',
@@ -632,9 +731,9 @@ test('writer timestamps require timezone-qualified RFC 3339 values', () => {
     '2026-08-29T25:00:00.000Z',
     '2026-08-29T19:00:00.0000Z',
   ]) {
-    assert.equal(assessAtomicOwnership(
-      { ...writerCapability, verifiedAt: malformed },
-      { now, repository: 'Jamula/Andreja', ownerId: 'coordinator-1' },
+    assert.equal(assessSingleCoordinatorProcessGuard(
+      repositoryReconciliation({ checkedAt: malformed }),
+      { now, repository: 'Jamula/Andreja', coordinatorId: 'coordinator-1' },
     ).available, false);
   }
 });
@@ -679,9 +778,10 @@ test('prompt and every orchestration contract carry the five-child wave rules', 
   assert.match(prompt, /NEXT_TICK_REQUIRED/);
   assert.match(prompt, /useful N\/5 target/);
   assert.match(prompt, /read-only/i);
-  assert.match(prompt, /atomic.*capabilit/i);
+  assert.match(prompt, /single-coordinator process guard/i);
+  assert.match(prompt, /best-effort repository reconciliation/i);
   assert.match(prompt, /generic Scribe/i);
-  assert.match(spawn, /Reserve five child issues/i);
+  assert.match(spawn, /Prepare five child issues/i);
   assert.match(spawn, /ambiguous.*creation/is);
   assert.match(client, /never\s+manufacture concurrency/i);
   assert.match(lifecycle, /every successfully created child returns/i);
@@ -718,5 +818,5 @@ test('prompt and every orchestration contract carry the five-child wave rules', 
     );
     assert.match(content, /READY_FOR_AGENT_MERGE/);
   }
-  assert.match(scribe, /exclusive retrospective completion/i);
+  assert.match(scribe, /dedicated retrospective completion/i);
 });

--- a/.squad/skills/squad-issue-drain/weekly-retrospective.js
+++ b/.squad/skills/squad-issue-drain/weekly-retrospective.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const {
+  assessSingleCoordinatorProcessGuard,
+} = require('./issue-drain');
+
 const WINDOW_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 const CANONICAL_PREFIX = 'log/weekly-retrospective-';
 const SCHEMA_MARKER = '<!-- weekly-retrospective:v1 -->';
@@ -428,22 +432,6 @@ function validateCompletionEvidence({
   return { valid: true };
 }
 
-function validateAtomicCompletionCapability(capability, repository) {
-  return Boolean(
-    capability
-    && typeof capability === 'object'
-    && !Array.isArray(capability)
-    && capability.verified === true
-    && capability.repositoryScoped === true
-    && capability.repository === repository
-    && capability.kind === 'conditional-create'
-    && typeof capability.tool === 'string'
-    && capability.tool.length > 0
-    && capability.createIfAbsent === true
-    && capability.conflictIsFailure === true,
-  );
-}
-
 function oneLine(value, name) {
   if (typeof value !== 'string') {
     throw new Error(`${name} must be a non-empty single line`);
@@ -480,8 +468,21 @@ function prepareCompletion({
   decisions = [],
   actions = [],
   verification,
-  atomicCompletionCapability,
+  coordinatorId,
+  reconciliation,
 }) {
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository || '')) {
+    return { ready: false, reason: 'repository-invalid', write: null };
+  }
+  const guard = assessSingleCoordinatorProcessGuard(reconciliation, {
+    now,
+    repository,
+    coordinatorId,
+  });
+  if (!guard.available) {
+    return { ready: false, reason: guard.reason, write: null };
+  }
+
   const admission = assessAdmission({
     now,
     logs,
@@ -489,17 +490,15 @@ function prepareCompletion({
     enumerationComplete,
   });
   if (admission.allowed) {
-    return { ready: false, reason: 'cycle-already-complete', write: null };
+    return {
+      ready: true,
+      reason: 'completion-already-recorded',
+      write: null,
+      key: admission.completionKey,
+    };
   }
   if (!admission.ceremonyRequired) {
     return { ready: false, reason: admission.reason, write: null };
-  }
-
-  if (!/^[^/\s]+\/[^/\s]+$/.test(repository || '')) {
-    return { ready: false, reason: 'repository-invalid', write: null };
-  }
-  if (!validateAtomicCompletionCapability(atomicCompletionCapability, repository)) {
-    return { ready: false, reason: 'atomic-completion-unavailable', write: null };
   }
 
   if (!evidence
@@ -611,6 +610,47 @@ function prepareCompletion({
   return { ready: true, reason: 'completion-ready', write: { key, content } };
 }
 
+function reconcileCompletionWrite({
+  expected,
+  logs = [],
+  stateAvailable = false,
+  enumerationComplete = false,
+}) {
+  if (stateAvailable !== true) {
+    return { completed: false, reason: 'state-backend-unavailable' };
+  }
+  if (enumerationComplete !== true) {
+    return { completed: false, reason: 'log-enumeration-incomplete' };
+  }
+  if (!expected
+      || typeof expected.key !== 'string'
+      || typeof expected.content !== 'string'
+      || !validateCompletedLog(expected).valid) {
+    return { completed: false, reason: 'expected-completion-invalid' };
+  }
+
+  const matches = logs.filter((log) => log?.key === expected.key);
+  if (matches.length === 0) {
+    return { completed: false, reason: 'completion-write-not-observed' };
+  }
+  if (matches.length !== 1 || matches[0].content !== expected.content) {
+    return { completed: false, reason: 'completion-write-conflict' };
+  }
+  const validation = validateCompletedLog(matches[0]);
+  if (!validation.valid) {
+    return {
+      completed: false,
+      reason: 'completion-write-invalid',
+      detail: validation.reason,
+    };
+  }
+  return {
+    completed: true,
+    reason: 'completion-record-confirmed',
+    key: expected.key,
+  };
+}
+
 module.exports = {
   CANONICAL_PREFIX,
   MAX_GITHUB_EVIDENCE_AGE_MILLISECONDS,
@@ -619,8 +659,8 @@ module.exports = {
   completionKey,
   cycleStart,
   prepareCompletion,
+  reconcileCompletionWrite,
   resolveActionCandidates,
-  validateAtomicCompletionCapability,
   validateCompletionEvidence,
   validateCompletedLog,
 };

--- a/.squad/skills/squad-issue-drain/weekly-retrospective.test.js
+++ b/.squad/skills/squad-issue-drain/weekly-retrospective.test.js
@@ -7,24 +7,34 @@ const test = require('node:test');
 const {
   assessAdmission,
   prepareCompletion: prepareCompletionForRepository,
+  reconcileCompletionWrite,
   resolveActionCandidates,
   validateCompletedLog,
 } = require('./weekly-retrospective');
 
 const now = '2026-08-28T22:03:38.453-07:00';
-const atomicCompletionCapability = {
-  verified: true,
-  repositoryScoped: true,
-  repository: 'Jamula/Andreja',
-  kind: 'conditional-create',
-  tool: 'test.conditionalCreate',
-  createIfAbsent: true,
-  conflictIsFailure: true,
-};
+
+function repositoryReconciliation(overrides = {}) {
+  return {
+    repository: 'Jamula/Andreja',
+    checkedAt: now,
+    complete: true,
+    sessions: [],
+    branches: [],
+    worktrees: [],
+    pullRequests: [],
+    reservations: [],
+    ledger: [],
+    issueReadiness: [],
+    ...overrides,
+  };
+}
 
 function prepareCompletion(input) {
   return prepareCompletionForRepository({
     repository: 'Jamula/Andreja',
+    coordinatorId: 'coordinator-1',
+    reconciliation: repositoryReconciliation(),
     ...input,
   });
 }
@@ -306,7 +316,6 @@ test('an interrupted ceremony cannot produce a completion write', () => {
       }),
       duplicateSearch: undefined,
     },
-    atomicCompletionCapability,
   });
 
   assert.equal(result.ready, false);
@@ -314,7 +323,7 @@ test('an interrupted ceremony cannot produce a completion write', () => {
   assert.equal(result.reason, 'duplicate-search-evidence-mismatch');
 });
 
-test('completion prepares one deterministic conditional create per UTC weekly cycle', () => {
+test('completion prepares one deterministic canonical write per UTC weekly cycle', () => {
   const blockers = ['#44', '#62'];
   const decisions = [{
     summary: 'Queue admission fails closed',
@@ -346,7 +355,6 @@ test('completion prepares one deterministic conditional create per UTC weekly cy
       decisions,
       actions,
     }),
-    atomicCompletionCapability,
   };
   const first = prepareCompletion(input);
   const second = prepareCompletion(input);
@@ -366,9 +374,21 @@ test('completion prepares one deterministic conditional create per UTC weekly cy
     ...input,
     logs: [first.write],
   });
-  assert.equal(afterWrite.ready, false);
-  assert.equal(afterWrite.reason, 'cycle-already-complete');
+  assert.equal(afterWrite.ready, true);
+  assert.equal(afterWrite.reason, 'completion-already-recorded');
   assert.equal(afterWrite.write, null);
+  assert.equal(afterWrite.key, first.write.key);
+
+  assert.deepEqual(reconcileCompletionWrite({
+    expected: first.write,
+    logs: [first.write],
+    stateAvailable: true,
+    enumerationComplete: true,
+  }), {
+    completed: true,
+    reason: 'completion-record-confirmed',
+    key: first.write.key,
+  });
 });
 
 test('state failures and malformed canonical records fail closed', () => {
@@ -514,7 +534,6 @@ test('completion preserves explicit no-item sentinels accepted by validation', (
     decisions: [],
     actions: [],
     verification: verificationFor({ shippedCount: 56, openCount: 27 }),
-    atomicCompletionCapability,
   });
 
   assert.equal(completion.ready, true);
@@ -556,7 +575,6 @@ test('completion fails closed on malformed caller entries for every section', ()
       decisions,
       actions,
     }),
-    atomicCompletionCapability,
   };
   const malformed = [
     { blockers: ['arbitrary text'] },
@@ -639,7 +657,6 @@ test('completion requires confirmed state availability and complete enumeration'
       openCount: 27,
     },
     verification: verificationFor({ shippedCount: 56, openCount: 27 }),
-    atomicCompletionCapability,
   };
 
   assert.deepEqual(prepareCompletion(input), {
@@ -690,7 +707,7 @@ test('completion requires confirmed state availability and complete enumeration'
   assert.equal(validateCompletedLog(completion.write).valid, true);
 });
 
-test('completion fails closed without verified atomic conditional create support', () => {
+test('completion does not depend on atomic capability and fails closed on guard conflict', () => {
   const input = {
     now,
     logs: [],
@@ -705,17 +722,45 @@ test('completion fails closed without verified atomic conditional create support
     verification: verificationFor(),
   };
 
-  assert.equal(prepareCompletion(input).reason, 'atomic-completion-unavailable');
-  assert.equal(
-    prepareCompletion({
-      ...input,
-      atomicCompletionCapability: {
-        ...atomicCompletionCapability,
-        repositoryScoped: false,
-      },
-    }).reason,
-    'atomic-completion-unavailable',
-  );
+  assert.equal(prepareCompletion(input).ready, true);
+  assert.equal(prepareCompletion({
+    ...input,
+    reconciliation: repositoryReconciliation({
+      ledger: [{
+        issue: 122,
+        state: 'active',
+        coordinatorId: 'coordinator-2',
+      }],
+    }),
+  }).reason, 'coordinator-reconciliation-conflict');
+});
+
+test('completion read-back distinguishes missing and conflicting state', () => {
+  const prepared = prepareCompletion({
+    now,
+    logs: [],
+    stateAvailable: true,
+    enumerationComplete: true,
+    evidence: {
+      windowStart: '2026-08-22T04:17:54.580Z',
+      windowEnd: '2026-08-29T04:17:54.580Z',
+      shippedCount: 0,
+      openCount: 0,
+    },
+    verification: verificationFor(),
+  }).write;
+  assert.equal(reconcileCompletionWrite({
+    expected: prepared,
+    logs: [],
+    stateAvailable: true,
+    enumerationComplete: true,
+  }).reason, 'completion-write-not-observed');
+  assert.equal(reconcileCompletionWrite({
+    expected: prepared,
+    logs: [{ ...prepared, content: `${prepared.content}\nconflict` }],
+    stateAvailable: true,
+    enumerationComplete: true,
+  }).reason, 'completion-write-conflict');
 });
 
 test('completion rejects stale or contradictory GitHub evidence', () => {
@@ -731,7 +776,6 @@ test('completion rejects stale or contradictory GitHub evidence', () => {
     stateAvailable: true,
     enumerationComplete: true,
     evidence,
-    atomicCompletionCapability,
   };
   const verification = verificationFor({ shippedCount: 1, openCount: 1 });
 
@@ -763,15 +807,6 @@ test('completion rejects stale or contradictory GitHub evidence', () => {
       github: { ...verification.github, repository: 'other/repository' },
     },
   }).reason, 'github-repository-mismatch');
-
-  assert.equal(prepareCompletion({
-    ...input,
-    atomicCompletionCapability: {
-      ...atomicCompletionCapability,
-      repository: 'other/repository',
-    },
-    verification,
-  }).reason, 'atomic-completion-unavailable');
 
   const duplicateIdentity = verification.github.shippedIssueUrls[0]
     .replace('/issues/1000', '/pull/01000');
@@ -815,8 +850,10 @@ test('the issue-drain contract and runbook require governed fail-closed recovery
   assert.match(prompt, /squad_state_list.*`log`/s);
   assert.match(prompt, /must not depend on the configured\s+`retro-enforcement` skill/i);
   assert.match(prompt, /orchestrator must not write `log\/` directly/i);
-  assert.match(prompt, /exactly one conditional-create attempt/i);
-  assert.match(prompt, /Plain `squad_state_write` is insufficient/i);
+  assert.match(prompt, /single-coordinator process guard/i);
+  assert.match(prompt, /best-effort repository reconciliation/i);
+  assert.match(prompt, /one `squad_state_write`/i);
+  assert.match(prompt, /re-lists and re-reads/i);
   assert.match(prompt, /limited\s+to millisecond precision/i);
   assert.match(prompt, /structured evidence, not caller-supplied/i);
   assert.match(
@@ -825,7 +862,7 @@ test('the issue-drain contract and runbook require governed fail-closed recovery
   );
   assert.match(
     coordinator,
-    /Weekly retrospective completion mode \(exclusive\)[\s\S]*atomic conditional-create tool/i,
+    /Weekly retrospective completion mode \(dedicated\)[\s\S]*one `squad_state_write`/i,
   );
   assert.match(
     coordinator,
@@ -842,8 +879,10 @@ test('the issue-drain contract and runbook require governed fail-closed recovery
     /Resume queue work only after the issue-drain\s+protocol confirms a valid durable completion record/i,
   );
   assert.match(runbook, /Operational owner.*Jett Reno/i);
-  assert.match(runbook, /Scribe alone completes the canonical `log\/` record/i);
-  assert.match(runbook, /interrupted before the final conditional create/i);
+  assert.match(runbook, /Scribe alone completes\s+the canonical `log\/` record/i);
+  assert.match(runbook, /interrupted before the final write/i);
+  assert.match(runbook, /single-coordinator process guard/i);
+  assert.match(runbook, /best-effort repository reconciliation/i);
   assert.match(runbook, /no more than three fractional-second\s+digits/i);
   assert.match(runbook, /caller self-assertion is not evidence/i);
   assert.match(runbook, /Never write.*runtime-owned.*directly/i);

--- a/.squad/templates/after-agent-reference.md
+++ b/.squad/templates/after-agent-reference.md
@@ -26,11 +26,11 @@ released the successfully created members of a wave:
 3. **Show compact results:** `{emoji} {Name} — {1-line summary of what they did}`
 
 4. **Spawn Scribe** (background, never wait). Only if agents ran or inbox has
-   files and no exclusive retrospective completion is pending, running,
-   or awaiting read-back. Exclusive completion takes precedence. Do not start
-   generic Scribe until its single conditional-create attempt has a reconciled
-   outcome:
-   For issue drain, the spawn manifest must preserve the reserved wave/batch ID,
+   files and no dedicated retrospective completion is pending, running,
+   or awaiting read-back. Retrospective completion takes precedence. Do not
+   start generic Scribe until its one canonical write has an exact reconciled
+   read-back:
+   For issue drain, the spawn manifest must preserve the prepared wave/batch ID,
    stable tokens, all successfully created children, stopped-partial status, ACK
    dispositions, and release state. Scribe must not turn missing/negative ACKs
    or uncertain creation into release, advancement, or replacement.

--- a/.squad/templates/client-compatibility-reference.md
+++ b/.squad/templates/client-compatibility-reference.md
@@ -9,7 +9,7 @@ Squad runs on multiple Copilot surfaces. The coordinator MUST detect its platfor
 Before spawning agents, determine the platform by checking available tools:
 
 1. **App mode** — `create_session` is available → persistent child sessions.
-   Issue drain may use reserved waves of five only when the App confirms that
+   Issue drain may use prepared waves of five only when the App confirms that
    capacity; a lower confirmed limit reduces the wave.
 
 2. **CLI mode** — `task` tool is available → full spawning control. Use `task` with `agent_type`, `mode`, `model`, `description`, `prompt` parameters. Collect results via `read_agent`.
@@ -22,14 +22,15 @@ Prefer `create_session` for issue-drain children. If both `task` and
 `runSubagent` are available outside App mode, prefer `task` (richer parameter
 surface).
 
-Issue-drain pacing overrides each client's generic fan-out behavior. Reserve
+Issue-drain pacing overrides each client's generic fan-out behavior. Prepare
 each selected issue, launch one child at each exact 10-second boundary, and use
 a supported one-time wake or `NEXT_TICK_REQUIRED` instead of sleeping. Do not
 wait for an individual ACK before the next same-wave launch. Do not start the
 next wave until every successfully created child returns a valid correlated
-ACK. A client without atomic reservation, confirmed capacity, or a supported
-wake/tick path must reduce capacity or remain read-only; it must never
-manufacture concurrency.
+ACK. A client without complete best-effort repository reconciliation, confirmed
+capacity, or a supported wake/tick path must reduce capacity or remain blocked;
+it must never manufacture concurrency. Missing atomic capability is not a
+blocker under the single-coordinator process guard.
 
 #### VS Code Spawn Adaptations
 
@@ -37,7 +38,7 @@ When in VS Code mode, the coordinator changes behavior in these ways:
 
 - **Spawning tool:** Use `runSubagent` instead of `task`. The prompt is the only required parameter — pass the full agent prompt (charter, identity, task, hygiene, response order) exactly as you would on CLI.
 - **Parallelism:** For ordinary routed work, spawn all concurrent agents in a
-  single turn. Issue drain is the exception: it paces one reserved child per
+  single turn. Issue drain is the exception: it paces one prepared child per
   10-second boundary and stops the remaining wave on failed/ambiguous creation,
   changed eligibility, lost capacity, or a closed safety gate.
 - **Model selection:** Accept the session model. Do NOT attempt per-spawn model selection or fallback chains — they only work on CLI. In Phase 1, all subagents use whatever model the user selected in VS Code's model picker.
@@ -64,6 +65,6 @@ When in VS Code mode, the coordinator changes behavior in these ways:
 The `sql` tool is **CLI-only**. It does not exist on VS Code, JetBrains, or
 GitHub.com. Cross-platform code paths must not depend on SQL. For runtime-owned
 Squad state, use the configured `squad_state` bridge only; never substitute
-filesystem writes on a non-local backend. If a surface cannot expose the
-verified repository-scoped atomic operation required by issue-drain, that
-surface remains read-only and makes no exclusivity claim.
+filesystem writes on a non-local backend. Issue drain uses the
+single-coordinator process guard with best-effort repository reconciliation;
+it does not claim cross-process exclusivity.

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -297,17 +297,20 @@ When spawning an agent to work on an issue, include this context block:
 Issue-drain admissions also follow the stricter wave lifecycle before this
 ordinary implementation flow:
 
-1. Reserve up to five independent issues under the verified atomic owner,
-   reduced by the lower confirmed platform limit.
-2. Create one reserved child at each exact 10-second boundary using a one-time
+1. Prepare up to five independent issues in the session ledger, reduced by the
+   lower confirmed platform limit.
+2. Immediately before each spawn, run the single-coordinator process guard and
+   best-effort repository reconciliation across sessions, branches, worktrees,
+   PRs, reservations/ledger, and issue readiness.
+3. Create one prepared child at each exact 10-second boundary using a one-time
    wake or `NEXT_TICK_REQUIRED`, without waiting for the preceding ACK.
-3. Stop all later launches on failed/ambiguous creation, changed eligibility,
+4. Stop all later launches on failed/ambiguous creation, changed eligibility,
    lost capacity, or a closed safety gate. Preserve created children; do not
    replace uncertainty.
-4. Keep created children paused until every successfully created child returns
+5. Keep created children paused until every successfully created child returns
    a valid correlated ACK. Missing or negative ACKs block; invalid/corrupt ACKs
    are a distinct failure. Inspect once at five minutes or restart.
-5. A completed wave may advance after the barrier. A stopped partial wave may
+6. A completed wave may advance after the barrier. A stopped partial wave may
    release ACKed created children but cannot begin the next wave until its stop
    reason and a fresh admission scan are reconciled.
 

--- a/.squad/templates/orchestration-log.md
+++ b/.squad/templates/orchestration-log.md
@@ -14,7 +14,7 @@
 | **Why this mode** | {Brief reason — e.g., "No hard data dependencies" or "User needs to approve architecture"} |
 | **Issue-drain wave** | {wave/batch ID or `not-applicable`} |
 | **Admission token** | {stable token or `not-applicable`} |
-| **Reservation / creation** | {reserved → created / failed / ambiguous / ineligible / unlaunched} |
+| **Guard / creation** | {prepared → created / failed / ambiguous / ineligible / unlaunched} |
 | **ACK / release** | {pending / valid / negative / invalid / released / stopped-partial} |
 | **Files authorized to read** | {Exact file paths the agent was told to read} |
 | **File(s) agent must produce** | {Exact file paths the agent is expected to create or modify} |
@@ -29,6 +29,6 @@
 3. **Update outcome AFTER the agent completes.** Fill in the Outcome field.
 4. **Never delete or edit past entries.** Append-only.
 5. **If a reviewer rejects work,** log the rejection as a new entry with the revision agent.
-6. **Issue-drain entries reflect the ledger.** Log only observed reservation,
+6. **Issue-drain entries reflect the ledger.** Log only observed guard,
    creation, ACK, and release outcomes. A stopped partial wave is not an invalid
    ACK set, and an uncertain child is never logged as replaced.

--- a/.squad/templates/ralph-instructions.md
+++ b/.squad/templates/ralph-instructions.md
@@ -18,7 +18,7 @@
     • Agent persona, tone, or verbosity for session output
 
   YOU CANNOT override via this file:
-    • Issue-drain safety — Ralph uses reserved waves of five, lower confirmed
+    • Issue-drain safety — Ralph uses prepared waves of five, lower confirmed
       capacity, exact 10-second spawn-attempt pacing, and the created-child ACK barrier
     • Core eligibility filter (squad/squad:* label required, not blocked, not assigned)
     • The underlying `gh` / Copilot CLI command used to spawn each session
@@ -47,16 +47,18 @@
 
 Read this file for your full instructions.  Follow ALL sections.
 MAXIMIZE SAFE PARALLELISM — enumerate all actionable issues, then admit them
-through `.squad/skills/squad-issue-drain/PROMPT.md`. Reserve waves of five or
-lower confirmed capacity. Launch one reserved member per exact 10-second
+through `.squad/skills/squad-issue-drain/PROMPT.md`. Prepare waves of five or
+lower confirmed capacity. Launch one prepared member per exact 10-second
 boundary without sleeping and without waiting for each individual ACK.
 
 ### Issue Selection
 
 Work on every open, unblocked, unassigned issue labeled `squad` or `squad:{member}`.
 Skip issues that are assigned to a human, blocked, or marked `status:on-hold`.
-Before creating a child, atomically reserve its issue. A failed/ambiguous
-creation, changed eligibility, lost capacity, or closed safety gate stops the
+Immediately before creating a child, run the single-coordinator process guard
+and best-effort repository reconciliation across sessions, branches, worktrees,
+PRs, reservations/ledger, and issue readiness. A failed/ambiguous creation,
+changed eligibility, lost capacity, or closed safety gate stops the
 remainder of the wave. Keep every successfully created child owned and paused
 until all such children return valid ACKs. Missing, negative, or corrupt ACKs
 block the next wave; inspect once after five minutes and never replace an

--- a/.squad/templates/ralph-reference.md
+++ b/.squad/templates/ralph-reference.md
@@ -41,11 +41,14 @@ remain fail-closed before Step 1 and follow the contract's recovery path. Do not
 duplicate its state algorithm or write runtime-owned state directly. Exclusive
 retrospective completion must finish before generic Scribe work starts.
 
-**Issue-drain wave contract:** Reserve at most five independent `READY` issues
-before creation, reduced by the lower confirmed platform limit. Launch one
-reserved child at each exact 10-second boundary using a supported one-time wake
+**Issue-drain wave contract:** Prepare at most five independent `READY` issues
+in the session ledger before creation, reduced by the lower confirmed platform
+limit. Immediately before each spawn, run the single-coordinator process guard
+and best-effort repository reconciliation across sessions, branches, worktrees,
+PRs, reservations/ledger, and issue readiness. Launch one prepared child at each
+exact 10-second boundary using a supported one-time wake
 or `NEXT_TICK_REQUIRED`; never sleep in a turn. Do not wait for one child's ACK
-before launching the next reserved member. Failed/ambiguous creation, changed
+before launching the next prepared member. Failed/ambiguous creation, changed
 eligibility, lost capacity, or a closed safety gate stops the rest of the wave.
 Keep successfully created children owned and paused. Release only after every
 successfully created child returns a valid correlated ACK. Missing or negative
@@ -84,7 +87,7 @@ gh pr list --state open --draft --json number,title,author,labels,checks --limit
 **Step 3 — Act on highest-priority item:**
 - Process one category at a time, highest priority first (untriaged > assigned > CI failures > review feedback > approved PRs)
 - For ordinary work, spawn agents as needed and collect results. For issue
-  drain, use the reserved five-child wave contract above.
+  drain, use the prepared five-child wave contract above.
 - **⚡ CRITICAL: After results are collected, DO NOT stop. DO NOT wait for user input. IMMEDIATELY go back to Step 1 and scan again.** This is a loop — Ralph keeps cycling until the board is clear or the user says "idle". Each cycle is one "round".
 - If multiple items exist in the same category, process ordinary routed work in
   parallel. Issue-drain children are paced one spawn attempt per 10-second

--- a/.squad/templates/scribe-charter.md
+++ b/.squad/templates/scribe-charter.md
@@ -9,14 +9,15 @@
 - **Style:** Silent. Never speaks to the user. Works in the background.
 - **Mode:** Always spawned as `mode: "background"`. Never blocks the conversation.
 
-## Exclusive retrospective completion
+## Dedicated retrospective completion
 
 Generic Scribe work must not run while weekly-retrospective completion is
-pending, running, or awaiting canonical read-back. In exclusive completion
-mode, perform only the single repository-scoped atomic conditional create
-authorized by issue drain. Do not use plain `squad_state_write`, overwrite an
-existing key, retry an uncertain result, or run normal inbox/log/history
-maintenance. A conflict or unavailable capability fails closed.
+pending, running, or awaiting canonical read-back. In dedicated completion mode,
+perform only the single canonical `squad_state_write` authorized by issue drain,
+then re-list and re-read exact content. Reuse an exact valid existing record
+without writing. Do not overwrite a conflicting key, retry an uncertain result,
+or run normal inbox/log/history maintenance. A conflict or incomplete
+best-effort repository reconciliation fails closed.
 
 ## Issue-drain wave evidence
 

--- a/.squad/templates/spawn-reference.md
+++ b/.squad/templates/spawn-reference.md
@@ -36,19 +36,24 @@ When `create_session` is available, spawn commit-producing agents as **sub-sessi
 
 **Constraints:**
 - **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
-- **Issue-drain wave cap:** Reserve five child issues before creation, reduced
+- **Issue-drain wave cap:** Prepare five child issues in the session ledger
+  before creation, reduced
   by lower verified platform capacity and every safety gate. Do not infer
   capacity from configured limits or prior success.
-- **Pacing:** Launch one reserved child at each exact 10-second boundary,
+- **Process guard:** Immediately before each spawn, run the single-coordinator
+  process guard and best-effort repository reconciliation across sessions,
+  branches, worktrees, PRs, reservations/ledger, and issue readiness.
+- **Pacing:** Launch one prepared child at each exact 10-second boundary,
   including boundaries after failures and fallback attempts. Use a supported
   one-time wake or `NEXT_TICK_REQUIRED`; never sleep inside a turn.
-- **ACK gate:** Preallocate a wave/batch ID and admission token per reservation.
+- **ACK gate:** Preallocate a wave/batch ID and admission token per prepared
+  ledger entry.
   Launch the next same-wave member without waiting for an individual ACK. Keep
   every created child paused until the spawn phase closes and all successfully
   created children return correlated valid ACKs.
 - **Partial wave:** Failed/ambiguous creation, changed eligibility, lost
   capacity, or a closed safety gate stops every later launch. Preserve created
-  children and their reservations. A stopped partial wave is not an
+  children and their ledger entries. A stopped partial wave is not an
   invalid/corrupt ACK set and cannot begin the next wave.
 - **Fallback:** A failed `create_session` may fall back exactly once only after
   definitive evidence that no session, branch, worktree, or PR was created.

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -477,8 +477,9 @@ Never crash or halt because an MCP tool is missing. MCP tools are enhancements, 
 > **⚠️ Exception:** Eager Execution does NOT apply during Init Mode Phase 1. Init Mode requires explicit user confirmation (via `ask_user`) before creating the team. Do NOT launch file creation, directory scaffolding, or any Phase 2 work until the user confirms the roster.
 
 > **⚠️ Issue-drain exception:** Queue work is governed by
-> `.squad/skills/squad-issue-drain/PROMPT.md`. Universal Section 0, verified
-> atomic issue reservations, lower App capacity, exact 10-second spawn-attempt
+> `.squad/skills/squad-issue-drain/PROMPT.md`. Universal Section 0, the
+> single-coordinator process guard with best-effort repository reconciliation,
+> lower App capacity, exact 10-second spawn-attempt
 > pacing without in-turn sleep, and the all-successfully-created-child ACK
 > barrier override eager execution and generic fan-out. Launch same-wave members
 > without waiting for individual ACKs. A failed/ambiguous creation, changed
@@ -520,7 +521,7 @@ Before spawning, assess: **is there a reason this MUST be sync?** If not, use ba
 ### Parallel Fan-Out
 
 This section governs ordinary routed work only. Issue-drain queue admission
-reserves up to five issues, launches one reserved child per exact 10-second
+prepares up to five issues, launches one prepared child per exact 10-second
 boundary without waiting for individual ACKs, and must not launch all children
 in one tool turn. It releases only after the spawn phase closes and every
 successfully created child returns a valid correlated ACK.
@@ -661,16 +662,17 @@ prompt: |
   Never speak to user. End with plain text summary after all tool calls.
 ```
 
-**Weekly retrospective completion mode (exclusive):** When `Retrospective with
+**Weekly retrospective completion mode (dedicated):** When `Retrospective with
 Enforcement` runs as the issue-drain admission gate, first prove that no generic
 Scribe is running; otherwise stop. Do not start generic Scribe work until the
-exclusive completion attempt finishes and its canonical record is re-read.
+dedicated completion attempt finishes and its canonical record is re-read.
 After the issue-drain contract returns `ready: true`, pass Scribe only its
-returned canonical key and content plus the exact verified repository-scoped
-atomic conditional-create tool. Scribe MUST make exactly one create-if-absent
-attempt; an existing key or uncertain result is failure and must not be
-overwritten or treated as completion. Plain `squad_state_write` does not
-establish exactly-once completion. In this mode suppress generic session,
+returned canonical key and content. After a complete listing proves the key
+absent, Scribe makes one `squad_state_write`, then re-lists and re-reads exact
+content. Reuse an exact valid existing record without another write. Missing,
+different, or uncertain read-back is failure and must not be overwritten or
+treated as completion. This single-coordinator process guard is best-effort
+repository reconciliation, not cross-process exclusivity. In this mode suppress generic session,
 ceremony, orchestration, and health logs plus inbox, decision, and history
 maintenance. This narrow override supersedes Scribe's normal logging contract
 only for this admission-gate ceremony.
@@ -705,7 +707,7 @@ Ceremonies are structured team meetings where agents align before or after work.
 1. Before spawning a work batch, check `.squad/ceremonies.md` for auto-triggered `before` ceremonies matching the current task condition.
 2. After a batch completes, check for `after` ceremonies. Manual ceremonies run only when the user asks.
 3. Spawn the facilitator (sync) using the template in the reference file. Facilitator spawns participants as sub-tasks.
-4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record, except `Retrospective with Enforcement` used as Ralph's admission gate MUST use the exclusive weekly retrospective completion mode above and MUST NOT create a generic ceremony or session log.
+4. For `before`: include ceremony summary in work batch spawn prompts. Spawn Scribe (background) to record, except `Retrospective with Enforcement` used as Ralph's admission gate MUST use the dedicated weekly retrospective completion mode above and MUST NOT create a generic ceremony or session log.
 5. **Ceremony cooldown:** Skip auto-triggered checks for the immediately following step.
 6. Show: `📋 {CeremonyName} completed — facilitated by {Lead}. Decisions: {count} | Action items: {count}.`
 
@@ -923,16 +925,17 @@ GitHub Issues command, recovery path, restart, heartbeat, or post-batch rescan
 may bypass it. Ralph MUST NOT scan or enumerate issues or PRs until that
 contract permits the requested read-only or writer mode. Section 0 owns the
 fail-closed checks and runtime-state protocol; do not reimplement them or write
-runtime-owned state directly. Writer admission additionally requires verified
-existing repository-scoped atomic lease or conditional-create/CAS capability.
-Without it, remain read-only and claim no exclusivity. If Section 0 runs
-`Retrospective with Enforcement`, use the exclusive weekly retrospective Scribe
+runtime-owned state directly. Writer admission additionally requires the
+single-coordinator process guard and complete best-effort repository
+reconciliation immediately before each spawn. Missing atomic capability does
+not block admission, mutation, retrospective completion, or child release. If
+Section 0 runs `Retrospective with Enforcement`, use the dedicated weekly retrospective Scribe
 completion mode in this file.
 
 Ralph must follow the five-child wave ledger rather than generic simultaneous
-fan-out: reserve each issue before creation, use a one-time wake or
+fan-out: prepare each issue before creation, use a one-time wake or
 `NEXT_TICK_REQUIRED` at every 10-second boundary, and do not wait for an
-individual ACK before launching the next reserved member. Any failed or
+individual ACK before launching the next prepared member. Any failed or
 ambiguous creation, changed eligibility, lost capacity, or closed safety gate
 stops the remaining wave. Every successfully created child remains owned and
 paused until the all-created-child ACK barrier passes. A negative, missing, or

--- a/docs/operations/weekly-retrospective.md
+++ b/docs/operations/weekly-retrospective.md
@@ -4,10 +4,12 @@
 
 **Operational owner:** Jett Reno owns the admission mechanism and this runbook.
 Ralph enforces the check before queue work, Picard facilitates the ceremony, and
-the Squad coordinator requests governed state operations. Scribe alone completes the canonical `log/` record through a verified,
-repository-scoped atomic conditional create supplied by the existing runtime.
-Plain state writes do not establish exclusivity. GitHub issues remain the
-action source of truth.
+the Squad coordinator requests governed state operations. Scribe alone completes
+the canonical `log/` record through a single `squad_state_write` followed by
+exact read-back under the single-coordinator process guard. The guard uses
+best-effort repository
+reconciliation; it is not distributed mutual exclusion or cross-process
+exclusivity. GitHub issues remain the action source of truth.
 
 Queue admission requires one valid completed retrospective no more than seven
 elapsed days old. Each UTC Monday-through-Sunday cycle has at most one durable
@@ -62,13 +64,16 @@ does not disable or relax admission.
    evidence fails closed; caller self-assertion is not evidence.
 7. Prove that generic Scribe work is quiescent. If it cannot be proven finished,
    stop. Do not start generic Scribe until completion is reconciled.
-8. Capability-detect an existing verified repository-scoped atomic
-   conditional-create operation. Without it, remain read-only and blocked; do
-   not substitute `squad_state_write`.
-9. Hand the returned key and content to exclusive Scribe. Scribe makes one
-   create-if-absent attempt. Conflict or uncertainty is failure, not overwrite
-   or success. The orchestrator never writes `log/` directly.
-10. Re-list and re-read the record, then resume queue work.
+8. Run the single-coordinator process guard and complete best-effort repository
+   reconciliation of sessions, branches, worktrees, PRs, reservations/ledger,
+   and issue readiness. Incomplete, stale, duplicate, or conflicting evidence
+   blocks completion.
+9. Hand the returned key and content to dedicated Scribe. After a complete
+   listing proves the key absent, Scribe makes one `squad_state_write`. The
+   orchestrator never writes `log/` directly.
+10. Re-list and re-read the record. Exact valid content confirms completion. An
+    exact valid existing record is reused idempotently without another write.
+    Missing or different content is a conflict and remains blocked.
 
 The completion record contains only the evidence window, shipped/open counts,
 blocker references, decision summaries/references, and action issue links. Do
@@ -92,9 +97,9 @@ with other entries invalidate the record and keep admission closed.
   the configured runtime state bridge, then rerun the round-start check.
 - **Optional enforcement component unavailable:** continue with the built-in
   issue-drain protocol; do not bypass the ceremony.
-- **Ceremony interrupted before the final conditional create:** rerun it. The absence of a
+- **Ceremony interrupted before the final write:** rerun it. The absence of a
   valid record intentionally keeps admission blocked.
-- **Interruption after the conditional create:** re-read and reuse the valid canonical
+- **Interruption after the write:** re-read and reuse the valid canonical
   record. Never create a second log.
 - **Existing malformed canonical key or duplicate cycle records:** stop
   admission and escalate to the Squad coordinator. Preserve the records for
@@ -102,8 +107,14 @@ with other entries invalidate the record and keep admission closed.
   approved recovery policy.
 - **GitHub evidence or duplicate search incomplete:** keep the ceremony open and
   admission blocked. Do not infer completion or create speculative actions.
-- **Atomic conditional-create unavailable:** remain read-only. Do not claim a
-  lease, write completion, admit children, or replace atomicity with convention.
+- **Atomic CAS, lease, or conditional-create unavailable:** continue under the
+  single-coordinator process guard. Capability absence alone does not block
+  completion. This is best-effort repository reconciliation, not a cross-process
+  safety claim.
+- **Guard conflict or incomplete reconciliation:** keep admission blocked.
+  Preserve state, re-enumerate every source, and escalate persistent conflicts.
+- **Uncertain write outcome:** re-list and re-read. Treat exact valid content as
+  completed; treat missing or different content as blocked. Never overwrite.
 
 Never write, edit, delete, or copy runtime-owned Squad state directly, and never
 use git-notes choreography. Recovery uses `squad_state_*` or governed memory


### PR DESCRIPTION
## Why

Repository-scoped atomic CAS, lease, and conditional-create capabilities were blocking ordinary issue admission and weekly retrospective completion even when one coordinator owned the process. This change replaces that prerequisite with a deterministic single-coordinator process guard while preserving duplicate detection and the existing safety gates.

Closes: N/A

## Approach

Admission now performs best-effort repository reconciliation immediately before each spawn across sessions, branches, worktrees, pull requests, reservations and ledger state, and current issue readiness. Canonical retrospective completion is idempotent with explicit conflict and recovery behavior, without claiming distributed mutual exclusion.

The existing JavaScript issue-drain tooling remains in this PR. Moving repository tools and skills to .NET is a separate follow-up rather than a partial conversion in this contract-focused change.

## Charter impact

Human agency, privacy, tenant isolation, evidence requirements, and app-owned landing behavior are unchanged. The guard is explicitly scoped to the normal single-coordinator case; concurrent independent coordinator processes can still race and must recover through repository reconciliation.

## Validation

- Focused issue-drain and weekly-retrospective test coverage was updated for admission without atomic capability, duplicate reconciliation, retrospective completion, and guard conflict/failure behavior.
- Existing clean-worktree, live-base, ACK barrier, pacing, privacy, validation, and merge gates remain represented in the contract and tests.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A