### PR TITLE
Use latest C# and centralize MSBuild metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,18 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisMode>All</AnalysisMode>
+    <Authors>Cyrus Jamula</Authors>
+    <Company>Jamula, Inc.</Company>
+    <Copyright>Copyright © Jamula, Inc.</Copyright>
     <Deterministic>true</Deterministic>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <Nullable>enable</Nullable>
+    <TargetFramework>net10.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/scripts/evidence/test-platform-spike/Directory.Packages.props
+++ b/scripts/evidence/test-platform-spike/Directory.Packages.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
+  </ItemGroup>
 </Project>

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -5,7 +5,7 @@
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
@@ -6,8 +6,8 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />


### PR DESCRIPTION
## Why

Keep every C# project on the repository's current compiler language version and enforce consistent package metadata, analyzer coverage, and central package management from shared MSBuild configuration.

Closes # N/A (no source issue was provided)

## Approach

Set `LangVersion=latest`, `AnalysisMode=All`, package metadata, and `ManagePackageVersionsCentrally=true` in the alphabetized root `Directory.Build.props` property group. The isolated test-platform spike previously opted out of central package management and declared inline package versions, so its existing versions now live in its local `Directory.Packages.props` and its project references consume them centrally.

All 11 tracked C# projects evaluate the requested settings without changing target frameworks or dependency versions.

## Charter impact

No user-facing behavior, data handling, AI behavior, stakeholder incentives, or ownership boundaries change. The update strengthens truthful build evidence by applying the same compiler and analyzer configuration across all C# projects. Stop condition: restore, build, tests, spike scenarios, or analyzer enforcement regress.

## Validation

Passed locally:

```powershell
dotnet restore Andreja.slnx
dotnet restore tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj
dotnet restore scripts\evidence\test-platform-spike\XunitV3Spike\XunitV3Spike.csproj
dotnet restore scripts\evidence\test-platform-spike\MSTestMtpSpike\MSTestMtpSpike.csproj

dotnet build Andreja.slnx --configuration Debug --no-restore
dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Debug --no-restore
dotnet build scripts\evidence\test-platform-spike\XunitV3Spike\XunitV3Spike.csproj --configuration Debug --no-restore
dotnet build scripts\evidence\test-platform-spike\MSTestMtpSpike\MSTestMtpSpike.csproj --configuration Debug --no-restore
dotnet test Andreja.slnx --configuration Debug --no-build

dotnet build Andreja.slnx --configuration Release --no-restore
dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Release --no-restore
dotnet test Andreja.slnx --configuration Release --no-build

pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1
dotnet build scripts\evidence\test-platform-spike\MSTestMtpSpike\MSTestMtpSpike.csproj --configuration Debug --no-restore -p:RunAnalyzerProbe=true
```

Restores passed. Debug and Release builds completed with 0 warnings and 0 errors. Solution tests passed with 275 Debug and 271 Release tests. The platform spike passed; the analyzer probe produced the expected `MSTEST0032` rejection. MSBuild evaluation confirmed `LangVersion=latest`, `ManagePackageVersionsCentrally=true`, `AnalysisMode=All`, and exact metadata for all 11 projects. `git diff --check` and clean worktree/index checks passed.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

Architecture/contracts, security/privacy/legal, cost/operability, and user help/release notes are not affected by this build configuration change.

## Stack

N/A. This PR targets `main` directly.