### PR TITLE
Use latest C# and centralize MSBuild properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,18 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>14.0</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisMode>All</AnalysisMode>
+    <Authors>Cyrus Jamula</Authors>
+    <Company>Jamula, Inc.</Company>
+    <Copyright>Copyright © Jamula, Inc.</Copyright>
     <Deterministic>true</Deterministic>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <Nullable>enable</Nullable>
+    <TargetFramework>net10.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/scripts/evidence/test-platform-spike/Directory.Packages.props
+++ b/scripts/evidence/test-platform-spike/Directory.Packages.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
+  </ItemGroup>
 </Project>

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -5,7 +5,7 @@
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />

--- a/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
+++ b/scripts/evidence/test-platform-spike/XunitV3Spike/XunitV3Spike.csproj
@@ -6,8 +6,8 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Adapters\Andreja.Adapters\Andreja.Adapters.csproj" />


### PR DESCRIPTION
## Why

Keep all C# projects on the current compiler language version and establish consistent repository-wide assembly metadata, analyzer settings, and central package version management.

N/A - no source issue.

## Approach

Centralizes `LangVersion=latest`, package version management, analyzer configuration, and package metadata in `Directory.Build.props`, with properties sorted alphabetically. Removes the test-platform spike projects' central package management opt-outs and moves their package versions into the existing `Directory.Packages.props` so all 11 C# projects inherit the same settings.

## Charter impact

No user-facing behavior, personal data handling, AI behavior, accessibility flow, or stakeholder incentives change. The centralized analyzer and deterministic-build settings improve evidence quality and maintainability without changing ownership or stop conditions.

## Validation

- `dotnet restore Andreja.slnx` - passed
- PostgreSQL integration project restore - passed
- Both test-platform spike project restores - passed
- Debug builds for the solution, PostgreSQL integration project, and both spike projects - passed with 0 warnings and 0 errors
- Release builds for the solution and PostgreSQL integration project - passed with 0 warnings and 0 errors
- `dotnet test Andreja.slnx --configuration Debug --no-build` - 275 passed
- `dotnet test Andreja.slnx --configuration Release --no-build` - 271 passed
- `pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1` - passed
- Analyzer probe produced the expected `MSTEST0032` failure, confirming `AnalysisMode=All` enforcement
- MSBuild property evaluation confirmed all 11 projects use `LangVersion=latest`, `ManagePackageVersionsCentrally=true`, `AnalysisMode=All`, and the requested metadata
- `git diff --check` - passed

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

N/A - standalone PR targeting `main`.