### PR TITLE
chore: refresh dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: "/scripts/evidence/test-platform-spike"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/.squad/templates"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="MSTest.Sdk/4.3.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
   <PropertyGroup>
     <TestingExtensionsProfile>Default</TestingExtensionsProfile>
-    <MicrosoftTestingExtensionsCodeCoverageVersion>18.10.0</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.11.0</MicrosoftTestingExtensionsCodeCoverageVersion>
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
   </PropertyGroup>
   <ItemGroup>

--- a/scripts/evidence/test-platform-spike/README.md
+++ b/scripts/evidence/test-platform-spike/README.md
@@ -1,7 +1,7 @@
 # Issue 108 test-platform spike
 
 This isolated harness compares xUnit.net v3 `xunit.v3` 4.0.0 and
-`MSTest.Sdk` 4.3.3 on Microsoft.Testing.Platform 2.3.3 with the repository's
+`MSTest.Sdk` 4.4.0 on Microsoft.Testing.Platform 2.4.0 with the repository's
 pinned .NET SDK 10.0.301. It is excluded from `Andreja.slnx` and does not replace
 or modify the production xUnit 2 suite.
 


### PR DESCRIPTION
## Why

The repository's Dependabot configuration was still an inert placeholder, and the isolated MSTest platform spike had fallen behind the current compatible test SDK and coverage extension. This restores automated dependency monitoring and keeps the evidence harness on supported stable packages.

No source issue.

## Approach

- Configure weekly Dependabot checks for the root and spike NuGet manifests, the Squad template npm manifest, GitHub Actions, and the root Dockerfile.
- Update the isolated spike from `MSTest.Sdk` 4.3.3 to 4.4.0 and `Microsoft.Testing.Extensions.CodeCoverage` 18.10.0 to 18.11.0.
- Update the spike documentation for the resulting Microsoft.Testing.Platform 2.4.0 baseline.

The main centrally managed NuGet packages, xUnit spike packages, and dependency-free npm manifest were already current and remain unchanged.

## Charter impact

Not applicable to human agency, data dignity, inclusion, AI safety, or stakeholder incentives because this is dependency automation and test-infrastructure maintenance. It improves operability and sustainability by reducing package drift and keeping update scopes explicit.

## Validation

- Dependabot YAML parsed successfully and all five configured update entries were structurally checked.
- `npm install --package-lock-only --ignore-scripts --prefix .squad\templates --dry-run` passed without manifest changes.
- Release restore/build passed for `Andreja.slnx` and `Andreja.PostgreSqlIntegrationTests.csproj`.
- Service-free tests passed: 253 unit and 18 architecture tests.
- Full `Invoke-Spike.ps1 -WarmRuns 3` harness passed with MSTest 4.4.0/MTP 2.4.0.
- Direct and transitive NuGet vulnerability audits reported no findings; direct outdated-package audits were clean.
- PostgreSQL integration runtime tests were not executed because the Docker Desktop daemon was unavailable; the project compiled successfully.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable (required after ADR 0006 acceptance)
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

- Parent/base for this layer: `u/cyrusjamula/refresh-tests-dependencies`
- Final integration base: `main`
- Layer order: test/dependency refresh parent, then this dependency-maintenance update