### PR TITLE
Refresh dependency maintenance and test-platform evidence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: "/scripts/evidence/test-platform-spike"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/.squad/templates"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="MSTest.Sdk/4.3.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
   <PropertyGroup>
     <TestingExtensionsProfile>Default</TestingExtensionsProfile>
-    <MicrosoftTestingExtensionsCodeCoverageVersion>18.10.0</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.11.0</MicrosoftTestingExtensionsCodeCoverageVersion>
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
   </PropertyGroup>
   <ItemGroup>

--- a/scripts/evidence/test-platform-spike/README.md
+++ b/scripts/evidence/test-platform-spike/README.md
@@ -1,7 +1,7 @@
 # Issue 108 test-platform spike
 
 This isolated harness compares xUnit.net v3 `xunit.v3` 4.0.0 and
-`MSTest.Sdk` 4.3.3 on Microsoft.Testing.Platform 2.3.3 with the repository's
+`MSTest.Sdk` 4.4.0 on Microsoft.Testing.Platform 2.4.0 with the repository's
 pinned .NET SDK 10.0.301. It is excluded from `Andreja.slnx` and does not replace
 or modify the production xUnit 2 suite.
 


### PR DESCRIPTION
## Why

Keep dependency maintenance automated across the repository and update the isolated MSTest/Microsoft.Testing.Platform evidence harness to current stable tooling. Independent server-side validation found no application or test-source regression from the upgrade.

N/A - no source issue was provided.

## Approach

- Configure weekly Dependabot coverage for NuGet, npm, GitHub Actions, and Docker dependency surfaces.
- Update the isolated MSTest spike to `MSTest.Sdk` 4.4.0 and code coverage extension 18.11.0.
- Align the spike documentation with Microsoft.Testing.Platform 2.4.0.
- Preserve the existing fail-closed PostgreSQL test policy; no test-source workaround or skipped-as-passed behavior was introduced.

## Charter impact

Maintenance-only change. It does not alter user agency, data handling, tenant boundaries, AI behavior, stakeholder incentives, or ownership. It improves evidence and operability by keeping dependency automation and test-platform validation current.

## Validation

Passed:

```powershell
dotnet build Andreja.slnx --configuration Release --no-restore
dotnet test Andreja.slnx --configuration Release --no-build --verbosity minimal
dotnet build tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --configuration Release --no-restore
pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1 -WarmRuns 3
```

Results:

- Release solution build: 0 warnings, 0 errors.
- Service-free tests: 271/271 passed (253 unit, 18 architecture).
- PostgreSQL integration project: Release compilation passed.
- Full upgraded spike: Debug/Release discovery, TRX, filtering, lifecycle, expected timeout, analyzer, and warm-run gates passed.

Environment limitation:

```powershell
dotnet test tests\Andreja.PostgreSqlIntegrationTests\Andreja.PostgreSqlIntegrationTests.csproj --verbosity minimal
```

Runtime execution is blocked because Docker and `ANDREJA_TEST_POSTGRES` are unavailable. All 22 cases fail closed at fixture construction with `BLOCKED: set ANDREJA_TEST_POSTGRES to a disposable local PostgreSQL database.` This is the documented repository policy for unavailable PostgreSQL evidence, not a regression.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable (required after ADR 0006
      acceptance)
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

Parent/base: `u/cyrusjamula/refresh-tests-dependencies`

Final base: `main`

Layer order: dependency/test refresh parent, then this validated maintenance layer.