### PR TITLE
Update MSTest evidence dependencies

### DIFF
--- a/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
+++ b/scripts/evidence/test-platform-spike/MSTestMtpSpike/MSTestMtpSpike.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="MSTest.Sdk/4.3.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
   <PropertyGroup>
     <TestingExtensionsProfile>Default</TestingExtensionsProfile>
-    <MicrosoftTestingExtensionsCodeCoverageVersion>18.10.0</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.11.0</MicrosoftTestingExtensionsCodeCoverageVersion>
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Why

Keep the test-platform evidence project on current stable MSTest and Microsoft Testing Platform coverage packages. This removes the remaining stale direct dependencies without changing the application or server dependency graph.

N/A - no source issue was provided.

## Approach

Upgrade `MSTest.Sdk` from 4.3.3 to 4.4.0 and `MicrosoftTestingExtensionsCodeCoverageVersion` from 18.10.0 to 18.11.0. The rest of the managed NuGet graph was already current and remains unchanged.

## Charter impact

Not applicable. This maintenance-only dependency refresh does not alter user agency, data handling, tenant boundaries, AI behavior, stakeholder incentives, or ownership.

## Validation

Passed:

```powershell
pwsh -NoProfile -File scripts\evidence\test-platform-spike\Invoke-Spike.ps1 -WarmRuns 3
dotnet list scripts\evidence\test-platform-spike\MSTestMtpSpike\MSTestMtpSpike.csproj package --outdated
git diff --check
```

The spike passed its Debug and Release builds, test discovery, filters, timeout probes, analyzer probe, lifecycle checks, and performance threshold. The final audit reported no outdated direct packages.

## Gates

- [x] Architecture/contract impact recorded or not applicable
- [x] Security/privacy/legal review recorded or not applicable
- [x] Cost/operability impact recorded or not applicable
- [x] Company charter impact recorded or not applicable (required after ADR 0006
      acceptance)
- [x] Applicable local build/test/lint/type/docs/config/scenario checks passed
- [x] User help/release notes updated or not applicable
- [x] No personal data, prompts, credentials, or connector content included

## Stack

Parent branch: `u/cyrusjamula/refresh-tests-dependencies`
Final base: `main`
Layer order: parent test/dependency refresh -> this focused MSTest evidence dependency update.