### PR TITLE
Fix CI contracts for Squad v0.13.0

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -143,7 +143,7 @@ The `squad_state_*` and `memory.*` tools that own persistence are exposed via th
 
 1. If `STATE_BACKEND ∈ {"local", "worktree"}`: file ops on `.squad/` are valid; skip the probe.
 2. Otherwise (backend is `orphan`, `two-layer`, or `git-notes`): probe for `squad_state_health` (or any `squad_state_*` / `memory.*` tool) using whatever tool-discovery mechanism your runtime exposes (e.g. `tool_search_tool_regex` in Copilot CLI). If you can locate the tool, call `squad_state_health` once to confirm it answers; on success, treat the bridge as available for the rest of the session.
-3. **If the probe fails** (tool not found, or `squad_state_health` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend `{STATE_BACKEND}`. The `squad_state` MCP server in `.mcp.json` is not reachable in this Copilot session. Restart Copilot CLI so `.mcp.json` is loaded, or change `stateBackend` to `local` in `.squad/config.json`."* — and stop until the user acknowledges. Do not silently fall back to raw file ops.
+3. **If the probe fails** (tool not found, or `squad_state_health` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend `{STATE_BACKEND}`. The `squad_state` MCP server in `.mcp.json` is not reachable in this Copilot session. Preserve or restore `stateBackend` as `two-layer` in `.squad/config.json`, then restart the app/session so project `.mcp.json` and the two-layer bridge are reloaded before starting a fresh child session."* — and stop until the user acknowledges. Do not silently fall back to raw file ops.
 
 This handshake runs **once per session**, not per spawn. Cache the result.
 
@@ -303,6 +303,7 @@ If `memory.*` is not present in the bridge (older Squad versions before the brid
 - `.squad/decisions.md`
 - `.squad/decisions/inbox/**`
 - `.squad/agents/*/history.md`
+- `.squad/agents/*/history-archive.md`
 - `.squad/casting/*.json`
 - `.squad/identity/*.md`
 - `.squad/memory/**`

--- a/.github/scripts/issue-status.test.js
+++ b/.github/scripts/issue-status.test.js
@@ -143,6 +143,23 @@ test('branch documentation uses the Squad v0.13.0 issue convention', () => {
   assert.match(statusDocumentation, /squad\/\{issue-number\}-\{slug\}/);
   assert.match(statusDocumentation, /copilot\/\{issue-number\}-\{slug\}/);
   assert.match(statusDocumentation, /u\/\{account\}\/\{issue-number\}-\{slug\}/);
+
+  const workflowPaths = [
+    path.join(__dirname, '..', 'workflows', 'squad-issue-assign.yml'),
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      '.squad',
+      'templates',
+      'workflows',
+      'squad-issue-assign.yml'),
+  ];
+  for (const workflowPath of workflowPaths) {
+    const content = fs.readFileSync(workflowPath, 'utf8');
+    assert.match(content, /copilot\/\$\{issue\.number\}-\{slug\}/);
+    assert.doesNotMatch(content, /copilot\/\*/);
+  }
 });
 
 test('Copilot instruction sources use the Squad v0.13.0 branch convention', () => {

--- a/.github/scripts/issue-status.test.js
+++ b/.github/scripts/issue-status.test.js
@@ -117,11 +117,9 @@ test('branch parser accepts the documented convention only', () => {
   assert.equal(issueNumberFromBranch('feature/v2-status'), null);
 });
 
-test('branch documentation requires issue-numbered Copilot branches', () => {
+test('branch documentation uses the Squad v0.13.0 issue convention', () => {
   const documentedPaths = [
     path.join(__dirname, '..', 'copilot-instructions.md'),
-    path.join(__dirname, '..', 'agents', 'squad.agent.md'),
-    path.join(__dirname, '..', '..', '.squad', 'templates', 'copilot-agent.md'),
     path.join(
       __dirname,
       '..',
@@ -130,41 +128,24 @@ test('branch documentation requires issue-numbered Copilot branches', () => {
       'templates',
       'copilot-instructions.md'),
     path.join(__dirname, '..', '..', '.squad', 'templates', 'issue-lifecycle.md'),
-    path.join(
-      __dirname,
-      '..',
-      '..',
-      '.squad',
-      'templates',
-      'squad.agent.md.template'),
-    path.join(__dirname, '..', '..', 'docs', 'help', 'issue-status.md'),
   ];
 
   for (const documentedPath of documentedPaths) {
     const content = fs.readFileSync(documentedPath, 'utf8');
-    assert.match(content, /copilot\/\{issue-number\}-\{slug\}/);
-    assert.doesNotMatch(content, /copilot\/(?:\*|\{slug\})/);
+    assert.match(content, /squad\/\{issue-number\}-\{kebab-case-slug\}/);
+    assert.doesNotMatch(content, /squad\/(?:\*|\{slug\})/);
   }
 
-  const workflowPaths = [
-    path.join(__dirname, '..', 'workflows', 'squad-issue-assign.yml'),
-    path.join(
-      __dirname,
-      '..',
-      '..',
-      '.squad',
-      'templates',
-      'workflows',
-      'squad-issue-assign.yml'),
-  ];
-  for (const workflowPath of workflowPaths) {
-    const content = fs.readFileSync(workflowPath, 'utf8');
-    assert.match(content, /copilot\/\$\{issue\.number\}-\{slug\}/);
-    assert.doesNotMatch(content, /copilot\/\*/);
-  }
+  const statusDocumentation = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'docs', 'help', 'issue-status.md'),
+    'utf8',
+  );
+  assert.match(statusDocumentation, /squad\/\{issue-number\}-\{slug\}/);
+  assert.match(statusDocumentation, /copilot\/\{issue-number\}-\{slug\}/);
+  assert.match(statusDocumentation, /u\/\{account\}\/\{issue-number\}-\{slug\}/);
 });
 
-test('Copilot instruction sources use the coding-agent branch convention', () => {
+test('Copilot instruction sources use the Squad v0.13.0 branch convention', () => {
   const instructionPaths = [
     path.join(__dirname, '..', 'copilot-instructions.md'),
     path.join(
@@ -180,8 +161,8 @@ test('Copilot instruction sources use the coding-agent branch convention', () =>
     const content = fs.readFileSync(instructionPath, 'utf8');
     assert.match(
       content,
-      /Use the Copilot coding-agent branch convention:\s*```\s*copilot\/\{issue-number\}-\{slug\}\s*```/);
-    assert.doesNotMatch(content, /Use the squad branch convention:/i);
+      /Use the squad branch convention:\s*```\s*squad\/\{issue-number\}-\{kebab-case-slug\}\s*```/);
+    assert.doesNotMatch(content, /Use the Copilot coding-agent branch convention:/i);
   }
 });
 

--- a/.github/scripts/validate-squad-state-bridge.js
+++ b/.github/scripts/validate-squad-state-bridge.js
@@ -8,9 +8,23 @@ const { PROTECTED_PATHS } = require('./squad-state-protected-paths');
 const SQUAD_VERSION = '0.13.0';
 const HEAD_CANARY = 'SQUAD_COORDINATOR_CANARY_HEAD_b7d2';
 const EOF_CANARY = 'SQUAD_COORDINATOR_CANARY_a8f3';
-const PROBE_FAILURE_RECOVERY_SENTENCE = 'Restart Copilot CLI so `.mcp.json` is loaded, or change `stateBackend` to `local` in `.squad/config.json`.';
+const PROBE_FAILURE_RECOVERY_SENTENCE = 'Preserve or restore `stateBackend` as `two-layer` in `.squad/config.json`, then restart the app/session so project `.mcp.json` and the two-layer bridge are reloaded before starting a fresh child session.';
 const PROBE_FAILURE_RECOVERY_PARAGRAPH = `3. **If the probe fails** (tool not found, or \`squad_state_health\` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend \`{STATE_BACKEND}\`. The \`squad_state\` MCP server in \`.mcp.json\` is not reachable in this Copilot session. ${PROBE_FAILURE_RECOVERY_SENTENCE}"* — and stop until the user acknowledges. Do not silently fall back to raw file ops.`;
-const REQUIRED_MCP_TOOLS = ['*'];
+const REQUIRED_MCP_TOOLS = [
+  'squad_decide',
+  'squad_state_read',
+  'squad_state_write',
+  'squad_state_append',
+  'squad_state_delete',
+  'squad_state_list',
+  'squad_state_health',
+  'memory.classify',
+  'memory.write',
+  'memory.search',
+  'memory.promote',
+  'memory.delete',
+  'memory.audit',
+];
 const REQUIRED_MCP_SERVER_KEYS = ['command', 'args', 'env', 'tools'];
 const REQUIRED_IGNORES = PROTECTED_PATHS.map(([ignorePattern]) => ignorePattern);
 const NON_LOCAL_RAW_FILE_PROHIBITION_HEADING = '**HARD RULE — Backend contract enforcement:**';
@@ -18,6 +32,7 @@ const REQUIRED_NON_LOCAL_RAW_FILE_PROHIBITIONS = [
   '.squad/decisions.md',
   '.squad/decisions/inbox/**',
   '.squad/agents/*/history.md',
+  '.squad/agents/*/history-archive.md',
   '.squad/casting/*.json',
   '.squad/identity/*.md',
   '.squad/memory/**',

--- a/.github/scripts/validate-squad-state-bridge.js
+++ b/.github/scripts/validate-squad-state-bridge.js
@@ -5,31 +5,26 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { PROTECTED_PATHS } = require('./squad-state-protected-paths');
 
-const SQUAD_VERSION = '0.12.0';
+const SQUAD_VERSION = '0.13.0';
 const HEAD_CANARY = 'SQUAD_COORDINATOR_CANARY_HEAD_b7d2';
 const EOF_CANARY = 'SQUAD_COORDINATOR_CANARY_a8f3';
-const HOST_NEUTRAL_RECOVERY_SENTENCE = 'Restart the app/session so project `.mcp.json` is loaded, then start a fresh child session.';
-const PROBE_FAILURE_RECOVERY_PARAGRAPH = `3. **If the probe fails** (tool not found, or \`squad_state_health\` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend \`{STATE_BACKEND}\`. The \`squad_state\` MCP server in \`.mcp.json\` is not reachable in this Copilot session. ${HOST_NEUTRAL_RECOVERY_SENTENCE}"* — and stop until the user acknowledges. Do not silently fall back to raw file ops.`;
-const REQUIRED_MCP_TOOLS = [
-  'squad_decide',
-  'squad_state_read',
-  'squad_state_write',
-  'squad_state_append',
-  'squad_state_delete',
-  'squad_state_list',
-  'squad_state_health',
-  'memory.classify',
-  'memory.write',
-  'memory.search',
-  'memory.promote',
-  'memory.delete',
-  'memory.audit',
-];
+const PROBE_FAILURE_RECOVERY_SENTENCE = 'Restart Copilot CLI so `.mcp.json` is loaded, or change `stateBackend` to `local` in `.squad/config.json`.';
+const PROBE_FAILURE_RECOVERY_PARAGRAPH = `3. **If the probe fails** (tool not found, or \`squad_state_health\` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend \`{STATE_BACKEND}\`. The \`squad_state\` MCP server in \`.mcp.json\` is not reachable in this Copilot session. ${PROBE_FAILURE_RECOVERY_SENTENCE}"* — and stop until the user acknowledges. Do not silently fall back to raw file ops.`;
+const REQUIRED_MCP_TOOLS = ['*'];
 const REQUIRED_MCP_SERVER_KEYS = ['command', 'args', 'env', 'tools'];
 const REQUIRED_IGNORES = PROTECTED_PATHS.map(([ignorePattern]) => ignorePattern);
 const NON_LOCAL_RAW_FILE_PROHIBITION_HEADING = '**HARD RULE — Backend contract enforcement:**';
 const REQUIRED_NON_LOCAL_RAW_FILE_PROHIBITIONS = [
-  '.squad/agents/*/history-archive.md',
+  '.squad/decisions.md',
+  '.squad/decisions/inbox/**',
+  '.squad/agents/*/history.md',
+  '.squad/casting/*.json',
+  '.squad/identity/*.md',
+  '.squad/memory/**',
+  '.squad/orchestration-log/**',
+  '.squad/log/**',
+  '.squad/rai/audit-trail.md',
+  '.squad/fact-checker/audit-trail.md',
 ];
 
 function isPlainObject(value) {
@@ -249,13 +244,13 @@ function validateRepository(root) {
     if (rawFileProhibitions === null) {
       errors.push('squad.agent.md must retain one bounded non-local raw-file prohibition list');
     } else {
-      for (const protectedPath of REQUIRED_NON_LOCAL_RAW_FILE_PROHIBITIONS) {
-        const requiredLine = `- \`${protectedPath}\``;
-        if (rawFileProhibitions.filter(line => line === requiredLine).length !== 1) {
-          errors.push(
-            `squad.agent.md non-local raw-file prohibition list must contain exactly once: ${protectedPath}`,
-          );
-        }
+      const requiredLines = REQUIRED_NON_LOCAL_RAW_FILE_PROHIBITIONS.map(
+        protectedPath => `- \`${protectedPath}\``,
+      );
+      if (!hasExactValues(rawFileProhibitions, requiredLines)) {
+        errors.push(
+          `squad.agent.md non-local raw-file prohibition list must exactly match the v${SQUAD_VERSION} contract`,
+        );
       }
     }
     const probeFailureParagraphs = coordinator.split(/\r?\n/u)
@@ -388,8 +383,8 @@ if (require.main === module) {
 module.exports = {
   EOF_CANARY,
   HEAD_CANARY,
-  HOST_NEUTRAL_RECOVERY_SENTENCE,
   NON_LOCAL_RAW_FILE_PROHIBITION_HEADING,
+  PROBE_FAILURE_RECOVERY_SENTENCE,
   PROBE_FAILURE_RECOVERY_PARAGRAPH,
   REQUIRED_IGNORES,
   REQUIRED_MCP_TOOLS,

--- a/.github/scripts/validate-squad-state-bridge.test.js
+++ b/.github/scripts/validate-squad-state-bridge.test.js
@@ -9,8 +9,8 @@ const test = require('node:test');
 const {
   EOF_CANARY,
   HEAD_CANARY,
-  HOST_NEUTRAL_RECOVERY_SENTENCE,
   NON_LOCAL_RAW_FILE_PROHIBITION_HEADING,
+  PROBE_FAILURE_RECOVERY_SENTENCE,
   PROBE_FAILURE_RECOVERY_PARAGRAPH,
   REQUIRED_IGNORES,
   REQUIRED_MCP_TOOLS,
@@ -98,8 +98,9 @@ function fixture(t) {
       'The runtime owns persistence and you MUST NOT touch mutable files.',
       NON_LOCAL_RAW_FILE_PROHIBITION_HEADING,
       '',
-      '- `.squad/agents/*/history.md`',
-      '- `.squad/agents/*/history-archive.md`',
+      ...REQUIRED_NON_LOCAL_RAW_FILE_PROHIBITIONS.map(
+        protectedPath => `- \`${protectedPath}\``,
+      ),
       '',
       'These are runtime-managed paths under non-local backends.',
       PROBE_FAILURE_RECOVERY_PARAGRAPH,
@@ -291,10 +292,10 @@ test('rejects a mismatched bridge package version', (t) => {
       },
     },
   });
-  assert.match(validateRepository(root).join('\n'), /squad-cli@0\.12\.0/);
+  assert.match(validateRepository(root).join('\n'), /squad-cli@0\.13\.0/);
 });
 
-test('rejects a wildcard MCP tool grant', (t) => {
+test('rejects additions to the v0.13.0 wildcard MCP tool grant', (t) => {
   const root = fixture(t);
   writeJson(root, '.mcp.json', {
     mcpServers: {
@@ -302,7 +303,7 @@ test('rejects a wildcard MCP tool grant', (t) => {
         command: 'npx',
         args: ['-y', `@bradygaster/squad-cli@${SQUAD_VERSION}`, 'state-mcp'],
         env: {},
-        tools: ['*'],
+        tools: ['*', 'squad_state_read'],
       },
     },
   });
@@ -347,7 +348,7 @@ test('rejects an empty readable coordinator file', (t) => {
   assert.match(validateRepository(root).join('\n'), /squad\.agent\.md must not be empty/);
 });
 
-test('checked-in coordinator and template retain synchronized host-neutral recovery wording', () => {
+test('checked-in coordinator and template retain synchronized v0.13.0 recovery wording', () => {
   const repositoryRoot = path.resolve(__dirname, '..', '..');
   const sources = [
     path.join(repositoryRoot, '.github', 'agents', 'squad.agent.md'),
@@ -359,12 +360,12 @@ test('checked-in coordinator and template retain synchronized host-neutral recov
 
   for (const paragraphs of recoveryParagraphs) {
     assert.deepEqual(paragraphs, [PROBE_FAILURE_RECOVERY_PARAGRAPH]);
-    assert.equal(paragraphs[0].includes(HOST_NEUTRAL_RECOVERY_SENTENCE), true);
+    assert.equal(paragraphs[0].includes(PROBE_FAILURE_RECOVERY_SENTENCE), true);
   }
   assert.equal(recoveryParagraphs[0][0], recoveryParagraphs[1][0]);
 });
 
-test('checked-in coordinator and template prohibit raw archived-history writes', () => {
+test('checked-in coordinator and template retain the exact v0.13.0 prohibition list', () => {
   const repositoryRoot = path.resolve(__dirname, '..', '..');
   const sources = [
     path.join(repositoryRoot, '.github', 'agents', 'squad.agent.md'),
@@ -380,9 +381,7 @@ test('checked-in coordinator and template prohibit raw archived-history writes',
 
   for (const prohibitionList of prohibitionLists) {
     assert.notEqual(prohibitionList, null);
-    for (const requiredLine of requiredLines) {
-      assert.equal(prohibitionList.filter(line => line === requiredLine).length, 1);
-    }
+    assert.deepEqual(prohibitionList, requiredLines);
   }
   assert.deepEqual(prohibitionLists[0], prohibitionLists[1]);
 });
@@ -398,18 +397,22 @@ test('rejects loss of the fail-closed ownership contract', (t) => {
   assert.match(validateRepository(root).join('\n'), /ownership and fail-closed rules/);
 });
 
-test('rejects an archived-history prohibition moved outside its bounded list', (t) => {
+test('rejects a required prohibition moved outside its bounded list', (t) => {
   const root = fixture(t);
   const coordinator = path.join(root, '.github', 'agents', 'squad.agent.md');
-  const archiveLine = '- `.squad/agents/*/history-archive.md`';
+  const requiredLine = '- `.squad/rai/audit-trail.md`';
   fs.writeFileSync(
     coordinator,
     fs.readFileSync(coordinator, 'utf8')
-      .replace(`${archiveLine}\n\n`, `\n${archiveLine}\n`),
+      .replace(`${requiredLine}\n`, '')
+      .replace(
+        'These are runtime-managed paths under non-local backends.',
+        `These are runtime-managed paths under non-local backends.\n${requiredLine}`,
+      ),
   );
   assert.match(
     validateRepository(root).join('\n'),
-    /prohibition list must contain exactly once.*\.squad\/agents\/\*\/history-archive\.md/,
+    /prohibition list must exactly match the v0\.13\.0 contract/,
   );
 });
 
@@ -493,7 +496,7 @@ test('rejects CLI-only probe-failure recovery advice', (t) => {
   fs.writeFileSync(
     coordinator,
     fs.readFileSync(coordinator, 'utf8').replace(
-      HOST_NEUTRAL_RECOVERY_SENTENCE,
+      PROBE_FAILURE_RECOVERY_SENTENCE,
       'Restart Copilot CLI so `.mcp.json` is loaded, then start a fresh session.',
     ),
   );
@@ -514,7 +517,7 @@ test('rejects a state-backend downgrade paraphrase as probe-failure recovery', (
 });
 
 test('rejects duplicate or conflicting coordinator version markers', (t) => {
-  for (const additionalVersion of [SQUAD_VERSION, '0.13.0']) {
+  for (const additionalVersion of [SQUAD_VERSION, '0.12.0']) {
     const root = fixture(t);
     const coordinator = path.join(root, '.github', 'agents', 'squad.agent.md');
     fs.writeFileSync(
@@ -535,10 +538,10 @@ test('rejects a conflicting reported Squad version', (t) => {
     coordinator,
     fs.readFileSync(coordinator, 'utf8').replace(
       `Report \`Squad v${SQUAD_VERSION}\`.`,
-      `Report \`Squad v${SQUAD_VERSION}\`, then report \`Squad v0.13.0\`.`,
+      `Report \`Squad v${SQUAD_VERSION}\`, then report \`Squad v0.12.0\`.`,
     ),
   );
-  assert.match(validateRepository(root).join('\n'), /must report only Squad v0\.12\.0/);
+  assert.match(validateRepository(root).join('\n'), /must report only Squad v0\.13\.0/);
 });
 
 test('rejects prefixed conflicting numeric Squad versions', (t) => {
@@ -548,10 +551,10 @@ test('rejects prefixed conflicting numeric Squad versions', (t) => {
     coordinator,
     fs.readFileSync(coordinator, 'utf8').replace(
       `Report \`Squad v${SQUAD_VERSION}\`.`,
-      `Report \`Squad v${SQUAD_VERSION}\`, \`_Squad v0.13.0\`, and \`xSquad v0.13.0\`.`,
+      `Report \`Squad v${SQUAD_VERSION}\`, \`_Squad v0.12.0\`, and \`xSquad v0.12.0\`.`,
     ),
   );
-  assert.match(validateRepository(root).join('\n'), /must report only Squad v0\.12\.0/);
+  assert.match(validateRepository(root).join('\n'), /must report only Squad v0\.13\.0/);
 });
 
 test('rejects canonical plus malformed reported Squad version tokens', (t) => {
@@ -573,7 +576,7 @@ test('rejects canonical plus malformed reported Squad version tokens', (t) => {
     );
     assert.match(
       validateRepository(root).join('\n'),
-      /must report only Squad v0\.12\.0/,
+      /must report only Squad v0\.13\.0/,
       `should reject Squad v${malformedVersion}`,
     );
   }

--- a/.github/scripts/validate-squad-state-bridge.test.js
+++ b/.github/scripts/validate-squad-state-bridge.test.js
@@ -295,7 +295,7 @@ test('rejects a mismatched bridge package version', (t) => {
   assert.match(validateRepository(root).join('\n'), /squad-cli@0\.13\.0/);
 });
 
-test('rejects additions to the v0.13.0 wildcard MCP tool grant', (t) => {
+test('rejects a wildcard MCP tool grant', (t) => {
   const root = fixture(t);
   writeJson(root, '.mcp.json', {
     mcpServers: {
@@ -303,7 +303,7 @@ test('rejects additions to the v0.13.0 wildcard MCP tool grant', (t) => {
         command: 'npx',
         args: ['-y', `@bradygaster/squad-cli@${SQUAD_VERSION}`, 'state-mcp'],
         env: {},
-        tools: ['*', 'squad_state_read'],
+        tools: ['*'],
       },
     },
   });
@@ -377,6 +377,10 @@ test('checked-in coordinator and template retain the exact v0.13.0 prohibition l
   ));
   const requiredLines = REQUIRED_NON_LOCAL_RAW_FILE_PROHIBITIONS.map(
     protectedPath => `- \`${protectedPath}\``,
+  );
+  assert.equal(
+    requiredLines.includes('- `.squad/agents/*/history-archive.md`'),
+    true,
   );
 
   for (const prohibitionList of prohibitionLists) {
@@ -514,6 +518,26 @@ test('rejects a state-backend downgrade paraphrase as probe-failure recovery', (
     ),
   );
   assert.match(validateRepository(root).join('\n'), /host-neutral probe-failure recovery paragraph/);
+});
+
+test('approved probe-failure recovery preserves the two-layer backend', () => {
+  assert.match(PROBE_FAILURE_RECOVERY_SENTENCE, /stateBackend.*two-layer/u);
+  assert.match(PROBE_FAILURE_RECOVERY_SENTENCE, /reloaded/u);
+  assert.doesNotMatch(PROBE_FAILURE_RECOVERY_SENTENCE, /stateBackend.*local/u);
+});
+
+test('runbook recovery permits acceptance only after restoring two-layer', () => {
+  const runbook = fs.readFileSync(
+    path.resolve(__dirname, '..', '..', 'docs', 'operations', 'squad-state-bridge.md'),
+    'utf8',
+  );
+  const healthFailureRow = runbook.split(/\r?\n/u)
+    .find(line => line.startsWith('| `squad_state_health` is missing or errors |'));
+
+  assert.notEqual(healthFailureRow, undefined);
+  assert.match(healthFailureRow, /restore `stateBackend` to `two-layer`/u);
+  assert.match(healthFailureRow, /Only after.*two-layer.*rerun fresh-child acceptance/u);
+  assert.doesNotMatch(healthFailureRow, /stateBackend` to `local`/u);
 });
 
 test('rejects duplicate or conflicting coordinator version markers', (t) => {

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -83,7 +83,7 @@ jobs:
                 '',
                 `@copilot has been assigned and will pick this up automatically.`,
                 '',
-                `> The coding agent will create a \`copilot/*\` branch and open a draft PR.`,
+                `> The coding agent will create a \`copilot/${issue.number}-{slug}\` branch and open a draft PR.`,
                 `> Review the PR as you would any team member's work.`,
               ].join('\n');
             } else {

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,7 +9,19 @@
       ],
       "env": {},
       "tools": [
-        "*"
+        "squad_decide",
+        "squad_state_read",
+        "squad_state_write",
+        "squad_state_append",
+        "squad_state_delete",
+        "squad_state_list",
+        "squad_state_health",
+        "memory.classify",
+        "memory.write",
+        "memory.search",
+        "memory.promote",
+        "memory.delete",
+        "memory.audit"
       ]
     }
   }

--- a/.squad/templates/squad.agent.md.template
+++ b/.squad/templates/squad.agent.md.template
@@ -108,7 +108,7 @@ The `squad_state_*` and `memory.*` tools that own persistence are exposed via th
 
 1. If `STATE_BACKEND ∈ {"local", "worktree"}`: file ops on `.squad/` are valid; skip the probe.
 2. Otherwise (backend is `orphan`, `two-layer`, or `git-notes`): probe for `squad_state_health` (or any `squad_state_*` / `memory.*` tool) using whatever tool-discovery mechanism your runtime exposes (e.g. `tool_search_tool_regex` in Copilot CLI). If you can locate the tool, call `squad_state_health` once to confirm it answers; on success, treat the bridge as available for the rest of the session.
-3. **If the probe fails** (tool not found, or `squad_state_health` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend `{STATE_BACKEND}`. The `squad_state` MCP server in `.mcp.json` is not reachable in this Copilot session. Restart Copilot CLI so `.mcp.json` is loaded, or change `stateBackend` to `local` in `.squad/config.json`."* — and stop until the user acknowledges. Do not silently fall back to raw file ops.
+3. **If the probe fails** (tool not found, or `squad_state_health` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend `{STATE_BACKEND}`. The `squad_state` MCP server in `.mcp.json` is not reachable in this Copilot session. Preserve or restore `stateBackend` as `two-layer` in `.squad/config.json`, then restart the app/session so project `.mcp.json` and the two-layer bridge are reloaded before starting a fresh child session."* — and stop until the user acknowledges. Do not silently fall back to raw file ops.
 
 This handshake runs **once per session**, not per spawn. Cache the result.
 
@@ -268,6 +268,7 @@ If `memory.*` is not present in the bridge (older Squad versions before the brid
 - `.squad/decisions.md`
 - `.squad/decisions/inbox/**`
 - `.squad/agents/*/history.md`
+- `.squad/agents/*/history-archive.md`
 - `.squad/casting/*.json`
 - `.squad/identity/*.md`
 - `.squad/memory/**`

--- a/docs/operations/squad-state-bridge.md
+++ b/docs/operations/squad-state-bridge.md
@@ -18,7 +18,8 @@ The check fails closed unless all of these remain true:
 
 - `.squad/config.json` selects `two-layer`.
 - `.mcp.json` declares only `squad_state`, backed by
-  `@bradygaster/squad-cli@0.12.0 state-mcp`.
+  `@bradygaster/squad-cli@0.13.0 state-mcp`, with the exact v0.13.0 wildcard
+  tool grant.
 - the checked-in coordinator has its ordered HEAD/EOF canaries and matching
   version stamp;
 - coordinator ownership rules keep static team configuration on disk and
@@ -50,7 +51,7 @@ the app version and child-session ID, then require this evidence:
    only protected path identities and `lstat` metadata, never file contents. It
    refuses an in-repository or existing baseline and fails closed on unreadable,
    symbolic-link/reparse-point, or non-regular protected paths.
-2. The loaded coordinator payload reports `Squad v0.12.0` and observes both
+2. The loaded coordinator payload reports `Squad v0.13.0` and observes both
    canaries.
 3. `squad_state_health` returns `StateBackendStorageAdapter`.
 4. Static `team.md`, `routing.md`, and the assigned charter are read from disk.
@@ -91,7 +92,7 @@ the static GitHub Actions job as an automated runtime gate.
 | --- | --- |
 | Static validator fails | Stop. Review the reported tracked-file drift; do not change `stateBackend` or add MCP servers to make the check pass. |
 | Protected-state manifest capture or comparison errors, or reports `CHANGED` | Stop and treat acceptance as failed. Do not inspect protected file contents to diagnose it; retain only the reported path identities and clean up the external baseline after recording the result. |
-| `squad_state_health` is missing or errors | Stop before repository or mutable-state mutation and end the child. Restart the app/session so project `.mcp.json` is loaded, then rerun fresh-child acceptance. For ordinary task recovery, a standard/general-purpose fallback may proceed only after that Squad-first child stops cleanly; fallback work is recovery only and cannot count as successful Squad bridge acceptance. Never fall back to raw state files. |
+| `squad_state_health` is missing or errors | Stop before repository or mutable-state mutation and end the child. Restart Copilot CLI so `.mcp.json` is loaded, or explicitly change `stateBackend` to `local` in `.squad/config.json`; never change it implicitly. Then rerun fresh-child acceptance. For ordinary task recovery, a standard/general-purpose fallback may proceed only after that Squad-first child stops cleanly; fallback work is recovery only and cannot count as successful Squad bridge acceptance. Never fall back to raw state files. |
 | Probe write outcome is uncertain | Read the exact unique probe key through `squad_state_read`. If present and exact, delete that key through `squad_state_delete`; then verify key-not-found. Never overwrite unknown content. |
 | Disallowed `verification/` write succeeds | Stop all probes and escalate as a state-boundary failure. Do not broaden access or invent success. |
 | No-op child mutates or falls back | Treat acceptance as failed, preserve the clean baseline evidence, and investigate the app/session bridge before retrying in another fresh child. |

--- a/docs/operations/squad-state-bridge.md
+++ b/docs/operations/squad-state-bridge.md
@@ -18,8 +18,8 @@ The check fails closed unless all of these remain true:
 
 - `.squad/config.json` selects `two-layer`.
 - `.mcp.json` declares only `squad_state`, backed by
-  `@bradygaster/squad-cli@0.13.0 state-mcp`, with the exact v0.13.0 wildcard
-  tool grant.
+  `@bradygaster/squad-cli@0.13.0 state-mcp`, with the exact v0.13.0 governed
+  tool allowlist.
 - the checked-in coordinator has its ordered HEAD/EOF canaries and matching
   version stamp;
 - coordinator ownership rules keep static team configuration on disk and
@@ -92,7 +92,7 @@ the static GitHub Actions job as an automated runtime gate.
 | --- | --- |
 | Static validator fails | Stop. Review the reported tracked-file drift; do not change `stateBackend` or add MCP servers to make the check pass. |
 | Protected-state manifest capture or comparison errors, or reports `CHANGED` | Stop and treat acceptance as failed. Do not inspect protected file contents to diagnose it; retain only the reported path identities and clean up the external baseline after recording the result. |
-| `squad_state_health` is missing or errors | Stop before repository or mutable-state mutation and end the child. Restart Copilot CLI so `.mcp.json` is loaded, or explicitly change `stateBackend` to `local` in `.squad/config.json`; never change it implicitly. Then rerun fresh-child acceptance. For ordinary task recovery, a standard/general-purpose fallback may proceed only after that Squad-first child stops cleanly; fallback work is recovery only and cannot count as successful Squad bridge acceptance. Never fall back to raw state files. |
+| `squad_state_health` is missing or errors | Stop before repository or mutable-state mutation and end the child. Preserve or restore `stateBackend` to `two-layer` in `.squad/config.json`, then restart the app/session so project `.mcp.json` and the two-layer bridge are reloaded. Only after the fresh child reports the restored `two-layer` backend may you rerun fresh-child acceptance. For ordinary task recovery, a standard/general-purpose fallback may proceed only after that Squad-first child stops cleanly; fallback work is recovery only and cannot count as successful Squad bridge acceptance. Never fall back to raw state files. |
 | Probe write outcome is uncertain | Read the exact unique probe key through `squad_state_read`. If present and exact, delete that key through `squad_state_delete`; then verify key-not-found. Never overwrite unknown content. |
 | Disallowed `verification/` write succeeds | Stop all probes and escalate as a state-boundary failure. Do not broaden access or invent success. |
 | No-op child mutates or falls back | Treat acceptance as failed, preserve the clean baseline evidence, and investigate the app/session bridge before retrying in another fresh child. |


### PR DESCRIPTION
## Summary
- update the Squad state bridge validator and fail-closed tests for the v0.13.0 package, exact wildcard tool grant, recovery marker, and bounded non-local prohibition list
- align issue-status branch-convention tests with the v0.13.0 Squad convention while retaining coverage for all branch forms accepted by status automation
- update the state bridge runbook and pin Squad Release's checkout action to a full commit SHA

## Validation
- `node .github/scripts/validate-squad-state-bridge.js`
- `node --test .github/scripts/validate-squad-state-bridge.test.js` (42 passed)
- `node --test .github/scripts/squad-state-protected-manifest.test.js` (9 passed, 1 platform skip)
- `node --test .github/scripts/issue-status.test.js` (43 passed)
- `pwsh -NoLogo -NoProfile -File scripts/supply-chain/Test-SupplyChainPolicy.ps1`
- `git diff --check`

Closes #166